### PR TITLE
Некоторые начертания в XeTeX по умолчанию

### DIFF
--- a/Dissertation/styles.tex
+++ b/Dissertation/styles.tex
@@ -8,6 +8,10 @@
   \setotherlanguage{english}
   \defaultfontfeatures{Ligatures=TeX,Mapping=tex-text}
   \setmainfont{Times New Roman}
+  \setsansfont{Arial}
+  \newfontfamily\cyrillicfontsf{Arial}
+  \setmonofont{Courier New}
+  \newfontfamily\cyrillicfonttt{Courier New}
 \else
   \IfFileExists{pscyr.sty}{\renewcommand{\rmdefault}{ftm}}{}
 \fi

--- a/Synopsis/styles.tex
+++ b/Synopsis/styles.tex
@@ -23,6 +23,10 @@
   \setotherlanguage{english}
   \defaultfontfeatures{Ligatures=TeX,Mapping=tex-text}
   \setmainfont{Times New Roman}
+  \setsansfont{Arial}
+  \newfontfamily\cyrillicfontsf{Arial}
+  \setmonofont{Courier New}
+  \newfontfamily\cyrillicfonttt{Courier New}
 \else
   \renewcommand{\rmdefault}{ftm}
 \fi


### PR DESCRIPTION
Настроил использование Arial в качестве шрифта без засечек и Courier New в качестве моноширинного шрифта по умолчанию. Добавил костыль для polyglossia, явно указывающий использование кириллических символов в этих шрифтах, без этого не работает.

Никто не запрещает конечному пользователю использовать любимый Comic Sans MS для основного текста и Webdings для остального — теперь это даже проще.