### PR TITLE
draft mode

### DIFF
--- a/Synopsis/Makefile
+++ b/Synopsis/Makefile
@@ -1,5 +1,13 @@
 all:
 	latexmk -pdf -pdflatex="xelatex %O %S" synopsis
+
+pdf:
+	latexmk -pdf -jobname=synopsis_pdf -silent  synopsis.tex
+xedraft:
+	latexmk -pdf -pdflatex="xelatex %O %S" draft
+draft:
+	latexmk -pdf -jobname=draft -silent  draft.tex
+
 clean:
 	latexmk -C synopsis
 	rm -f synopsis.bbl

--- a/Synopsis/draft.tex
+++ b/Synopsis/draft.tex
@@ -1,0 +1,599 @@
+\documentclass[a4paper,14pt]{extarticle} %,twoside
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%\input{../common/packages}  % Пакеты общие для диссертации и автореферата
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% Проверка используемого TeX-движка %%%
+\usepackage{iftex}
+\newif\ifxetexorluatex   % определяем новый условный оператор (http://tex.stackexchange.com/a/47579/79756)
+\ifXeTeX
+    \xetexorluatextrue
+\else
+    \ifLuaTeX
+        \xetexorluatextrue
+    \else
+        \xetexorluatexfalse
+    \fi
+\fi
+
+%%% Поля и разметка страницы %%%
+%\usepackage{pdflscape}                              % Для включения альбомных страниц
+%\usepackage{geometry}                               % Для последующего задания полей
+
+%%% Математические пакеты %%%
+\usepackage{amsmath}  % Математические дополнения от AMS
+%\usepackage{mathtools}                              % Добавляет окружение multlined
+
+%%%% Установки для размера шрифта 14 pt %%%%
+%% Формирование переменных и констант для сравнения (один раз для всех подключаемых файлов)%%
+%% должно располагаться до вызова пакета fontspec или polyglossia, потому что они сбивают его работу
+\newlength{\curtextsize}
+\newlength{\bigtextsize}
+\setlength{\bigtextsize}{13.9pt}
+
+\makeatletter
+%\show\f@size                                       % неплохо для отслеживания, но вызывает стопорение процесса, если документ компилируется без команды  -interaction=nonstopmode 
+\setlength{\curtextsize}{\f@size pt}
+\makeatother
+
+%%% Кодировки и шрифты %%%
+\ifxetexorluatex
+    \usepackage{polyglossia}                        % Поддержка многоязычности (fontspec подгружается автоматически)
+\else
+    \RequirePDFTeX                                  % tests for PDFTEX use and throws an error if a different engine is being used
+   %%% Решение проблемы копирования текста в буфер кракозябрами
+%    \input glyphtounicode.tex
+%    \input glyphtounicode-cmr.tex %from pdfx package
+%    \pdfgentounicode=1
+%    \usepackage{cmap}                               % Улучшенный поиск русских слов в полученном pdf-файле
+%    \defaulthyphenchar=127                          % Если стоит до fontenc, то переносы не впишутся в выделяемый текст при копировании его в буфер обмена
+%    \usepackage[T2A]{fontenc}                       % Поддержка русских букв
+    \usepackage[utf8]{inputenc}                     % Кодировка utf8
+    \usepackage[english, russian]{babel}            % Языки: русский, английский
+%    \IfFileExists{pscyr.sty}{\usepackage{pscyr}}{}  % Красивые русские шрифты
+\fi
+
+%%% Оформление абзацев %%%
+% \usepackage{indentfirst}                            % Красная строка
+
+%%% Цвета %%%
+% \usepackage[dvipsnames,usenames]{color}
+% \usepackage{colortbl}
+%\usepackage[dvipsnames, table, hyperref, cmyk]{xcolor} % Вероятно, более новый вариант, вместо предыдущих двух строк. Конвертация всех цветов в cmyk заложена как удовлетворение возможного требования типографий. Возможно конвертирование и в rgb.
+
+%%% Таблицы %%%
+% \usepackage{longtable}                              % Длинные таблицы
+% \usepackage{multirow,makecell,array}                % Улучшенное форматирование таблиц
+% \usepackage{booktabs}                               % Возможность оформления таблиц в классическом книжном стиле (при правильном использовании не противоречит ГОСТ)
+
+%%% Общее форматирование
+%\usepackage{soulutf8}                               % Поддержка переносоустойчивых подчёркиваний и зачёркиваний
+%\usepackage{icomma}                                 % Запятая в десятичных дробях
+
+
+% % %%% Гиперссылки %%%
+% \usepackage{hyperref}
+\newcommand{\texorpdfstring}[2]{#1}
+
+%%% Изображения %%%
+\usepackage{graphicx}                               % Подключаем пакет работы с графикой
+
+%%% Списки %%%
+%\usepackage{enumitem}
+
+% %%% Подписи %%%
+% \usepackage{caption}                                % Для управления подписями (рисунков и таблиц) % Может управлять номерами рисунков и таблиц с caption %Иногда может управлять заголовками в списках рисунков и таблиц
+% \usepackage{subcaption}                             % Работа с подрисунками и подобным
+
+%%% Интервалы %%%
+%\usepackage[onehalfspacing]{setspace}               % Опция запуска пакета правит не только интервалы в обычном тексте, но и формульные
+
+%%% Счётчики %%%
+\usepackage[figure,table]{totalcount}               % Счётчик рисунков и таблиц
+\usepackage{totcount}                               % Пакет создания счётчиков на основе последнего номера подсчитываемого элемента (может требовать дважды компилировать документ)
+\usepackage{totpages}                               % Счётчик страниц, совместимый с hyperref (ссылается на номер последней страницы). Желательно ставить последним пакетом в преамбуле
+
+% %%% Продвинутое управление групповыми ссылками (пока только формулами) %%%
+% \ifxetexorluatex
+%     \usepackage{cleveref}                           % cleveref корректно считывает язык из настроек polyglossia
+% \else
+%     \usepackage[russian]{cleveref}                  % cleveref имеет сложности со считыванием языка из babel. Такое решение русификации вывода выбрано вместо определения в documentclass из опасности что-то лишнее передать во все остальные пакеты, включая библиографию.
+% \fi
+% \creflabelformat{equation}{#2#1#3}                  % Формат по умолчанию ставил круглые скобки вокруг каждого номера ссылки, теперь просто номера ссылок без какого-либо дополнительного оформления
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%\input{synpackages}         % Пакеты для автореферата
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%\input{userpackages}        % Пакеты для специфических пользовательских задач
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%\input{../common/newnames}  % Новые переменные, которые могут использоваться во всём проекте
+% Новые переменные, которые могут использоваться во всём проекте
+\newcommand{\authorbibtitle}{Публикации автора по теме диссертации}
+\newcommand{\fullbibtitle}{Список литературы} % (ГОСТ Р 7.0.11-2011, 4)
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%\input{setup}               % Упрощённые настройки шаблона 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%% Файл упрощённых настроек шаблона диссертации %%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%        Подключение пакетов                 %%%
+\usepackage{ifthen}                 % добавляет ifthenelse
+%%% Инициализирование переменных, не трогать!  %%%
+\newcounter{bibliosel}
+% \newcounter{tabcap}
+% \newcounter{tablaba}
+% \newcounter{tabtita}
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%% Область упрощённого управления оформлением %%%
+
+%% Библиография
+
+%% Внимание! При использовании bibtex8 необходимо удалить все
+%% цитирования из  ../common/characteristic.tex 
+\setcounter{bibliosel}{1}           % 0 --- встроенная реализация с загрузкой файла через движок bibtex8; 1 --- реализация пакетом biblatex через движок biber
+
+% %% Подпись таблиц
+% \setcounter{tabcap}{0}              % 0 --- по ГОСТ, номер таблицы и название разделены тире, выровнены по левому краю, при необходимости на нескольких строках; 1 --- подпись таблицы не по ГОСТ, на двух и более строках, дальнейшие настройки: 
+% %Выравнивание первой строки, с подписью и номером
+% \setcounter{tablaba}{2}             % 0 --- по левому краю; 1 --- по центру; 2 --- по правому краю
+% %Выравнивание строк с самим названием таблицы
+% \setcounter{tabtita}{1}             % 0 --- по левому краю; 1 --- по центру; 2 --- по правому краю
+
+%%% Цвета гиперссылок %%%
+% Latex color definitions: http://latexcolor.com/
+% \definecolor{linkcolor}{rgb}{0.9,0,0}
+% \definecolor{citecolor}{rgb}{0,0.6,0}
+% \definecolor{urlcolor}{rgb}{0,0,1}
+%\definecolor{linkcolor}{rgb}{0,0,0} %black
+%\definecolor{citecolor}{rgb}{0,0,0} %black
+%\definecolor{urlcolor}{rgb}{0,0,0} %black
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\input{../common/data}      % Основные сведения
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%\input{../common/styles}    % Стили общие для диссертации и автореферата
+%%% Макет страницы %%%
+% Выставляем значения полей (ГОСТ 7.0.11-2011, 5.3.7)
+%\geometry{a4paper,top=2cm,bottom=2cm,left=2.5cm,right=1cm}
+
+%%% Кодировки и шрифты %%%
+\ifxetexorluatex
+    \setmainlanguage[babelshorthands=true]{russian}  % Язык по-умолчанию русский с поддержкой приятных команд пакета babel
+    \setotherlanguage{english}                       % Дополнительный язык = английский (в американской вариации по-умолчанию)
+    \ifXeTeX
+        \defaultfontfeatures{Ligatures=TeX,Mapping=tex-text}
+    \else
+        \defaultfontfeatures{Ligatures=TeX}
+    \fi
+    \setmainfont{Times New Roman}
+    \newfontfamily\cyrillicfont{Times New Roman}
+    \setsansfont{Arial}
+    \newfontfamily\cyrillicfontsf{Arial}
+    \setmonofont{Courier New}
+    \newfontfamily\cyrillicfonttt{Courier New}
+\else
+    \IfFileExists{pscyr.sty}{\renewcommand{\rmdefault}{ftm}}{}
+\fi
+
+%%% Интервалы %%%
+%linespread-реализация ближе к реализации полуторного интервала в ворде.
+%setspace реализация заточена под шрифты 10, 11, 12pt, под остальные кегли хуже, но всё же ближе к типографской классике. 
+%\linespread{1.3}                    % Полуторный интервал (ГОСТ Р 7.0.11-2011, 5.3.6)
+
+%%% Выравнивание и переносы %%%
+\sloppy                             % Избавляемся от переполнений
+\clubpenalty=10000                  % Запрещаем разрыв страницы после первой строки абзаца
+\widowpenalty=10000                 % Запрещаем разрыв страницы после последней строки абзаца
+
+%%% Изображения %%%
+\graphicspath{{../images/}{images/}}         % Пути к изображениям
+
+% %%% Подписи %%%
+% \captionsetup{%
+% singlelinecheck=off,                % Многострочные подписи, например у таблиц
+% skip=2pt,                           % Вертикальная отбивка между подписью и содержимым рисунка или таблицы определяется ключом
+% justification=centering,            % Центрирование подписей, заданных командой \caption
+% }
+
+% %%% Рисунки %%%
+% \DeclareCaptionLabelSeparator*{emdash}{~--- }             % (ГОСТ 2.105, 4.3.1)
+% \captionsetup[figure]{labelsep=emdash,font=onehalfspacing,position=bottom}
+
+% %%% Таблицы %%%
+% \ifthenelse{\equal{\thetabcap}{0}}{%
+%     \newcommand{\tabcapalign}{\raggedright}  % по левому краю страницы или аналога parbox
+% }
+
+% \ifthenelse{\equal{\thetablaba}{0} \AND \equal{\thetabcap}{1}}{%
+%     \newcommand{\tabcapalign}{\raggedright}  % по левому краю страницы или аналога parbox
+% }
+
+% \ifthenelse{\equal{\thetablaba}{1} \AND \equal{\thetabcap}{1}}{%
+%     \newcommand{\tabcapalign}{\centering}    % по центру страницы или аналога parbox
+% }
+
+% \ifthenelse{\equal{\thetablaba}{2} \AND \equal{\thetabcap}{1}}{%
+%     \newcommand{\tabcapalign}{\raggedleft}   % по правому краю страницы или аналога parbox
+% }
+
+% \ifthenelse{\equal{\thetabtita}{0} \AND \equal{\thetabcap}{1}}{%
+%     \newcommand{\tabtitalign}{\raggedright}  % по левому краю страницы или аналога parbox
+% }
+
+% \ifthenelse{\equal{\thetabtita}{1} \AND \equal{\thetabcap}{1}}{%
+%     \newcommand{\tabtitalign}{\centering}    % по центру страницы или аналога parbox
+% }
+
+% \ifthenelse{\equal{\thetabtita}{2} \AND \equal{\thetabcap}{1}}{%
+%     \newcommand{\tabtitalign}{\raggedleft}   % по правому краю страницы или аналога parbox
+% }
+
+% \DeclareCaptionFormat{tablenocaption}{\tabcapalign #1\strut}        % Наименование таблицы отсутствует
+% \ifthenelse{\equal{\thetabcap}{0}}{%
+%     \DeclareCaptionFormat{tablecaption}{\tabcapalign #1#2#3}
+%     \captionsetup[table]{labelsep=emdash}                       % тире как разделитель идентификатора с номером от наименования
+% }{%
+%     \DeclareCaptionFormat{tablecaption}{\tabcapalign #1#2\par%  % Идентификатор таблицы на отдельной строке
+%         \tabtitalign{#3}}                                       % Наименование таблицы строкой ниже
+%     \captionsetup[table]{labelsep=space}                        % пробельный разделитель идентификатора с номером от наименования
+% }
+% \captionsetup[table]{format=tablecaption,singlelinecheck=off,font=onehalfspacing,position=top,skip=0pt}  % многострочные наименования и прочее
+% \DeclareCaptionLabelFormat{continued}{Продолжение таблицы~#2}
+
+% %%% Подписи подрисунков %%%
+% \renewcommand{\thesubfigure}{\asbuk{subfigure}}           % Буквенные номера подрисунков
+% \captionsetup[subfigure]{font={normalsize},               % Шрифт подписи названий подрисунков (не отличается от основного)
+%     labelformat=brace,                                    % Формат обозначения подрисунка
+%     justification=centering,                              % Выключка подписей (форматирование), один из вариантов            
+% }
+%\DeclareCaptionFont{font12pt}{\fontsize{12pt}{13pt}\selectfont} % объявляем шрифт 12pt для использования в подписях, тут же надо интерлиньяж объявлять, если не наследуется
+%\captionsetup[subfigure]{font={font12pt}}                 % Шрифт подписи названий подрисунков (всегда 12pt)
+
+% %%% Настройки гиперссылок %%%
+% \ifLuaTeX
+%     \hypersetup{
+%         unicode,                % Unicode encoded PDF strings
+%     }
+% \fi
+
+% \hypersetup{
+%     linktocpage=true,           % ссылки с номера страницы в оглавлении, списке таблиц и списке рисунков
+% %    linktoc=all,                % both the section and page part are links
+% %    pdfpagelabels=false,        % set PDF page labels (true|false)
+%     plainpages=false,           % Forces page anchors to be named by the Arabic form  of the page number, rather than the formatted form
+%     colorlinks,                 % ссылки отображаются раскрашенным текстом, а не раскрашенным прямоугольником, вокруг текста
+%     linkcolor={linkcolor},      % цвет ссылок типа ref, eqref и подобных
+%     citecolor={citecolor},      % цвет ссылок-цитат
+%     urlcolor={urlcolor},        % цвет гиперссылок
+% %    hidelinks,                  % Hide links (removing color and border)
+%     pdftitle={\thesisTitle},    % Заголовок
+%     pdfauthor={\thesisAuthor},  % Автор
+%     pdfsubject={\thesisSpecialtyNumber\ \thesisSpecialtyTitle},      % Тема
+% %    pdfcreator={Создатель},     % Создатель, Приложение
+% %    pdfproducer={Производитель},% Производитель, Производитель PDF
+%     pdfkeywords={\keywords},    % Ключевые слова
+%     pdflang={ru},
+% }
+
+%%% Шаблон %%%
+\DeclareRobustCommand{\todo}{}       % решаем проблему превращения названия цвета в результате \MakeUppercase, http://tex.stackexchange.com/a/187930/79756 , \DeclareRobustCommand protects \todo from expanding inside \MakeUppercase
+%\setlength{\parindent}{2.5em}                       % Абзацный отступ. Должен быть одинаковым по всему тексту и равен пяти знакам (ГОСТ Р 7.0.11-2011, 5.3.7).
+
+% %%% Списки %%%
+% % Используем дефис для ненумерованных списков (ГОСТ 2.105-95, 4.1.7)
+% \renewcommand{\labelitemi}{\normalfont\bfseries{--}} 
+% \setlist{nosep,%                                    % Единый стиль для всех списков (пакет enumitem), без дополнительных интервалов.
+%     labelindent=\parindent,leftmargin=*%            % Каждый пункт, подпункт и перечисление записывают с абзацного отступа (ГОСТ 2.105-95, 4.1.8)
+% }
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%\input{synstyles}           % Стили для автореферата
+% %%% Макет страницы %%%
+% \oddsidemargin=-13pt
+% \topmargin=-66pt
+% \headheight=12pt
+% \headsep=38pt
+% \textheight=732pt
+% \textwidth=484pt
+% \marginparsep=14pt
+% \marginparwidth=43pt
+% \footskip=14pt
+% \marginparpush=7pt
+% \hoffset=0pt
+% \voffset=0pt
+% %\paperwidth=597pt
+% %\paperheight=845pt
+% \parindent=1.5cm                  % Размер табуляции (для красной строки) в начале каждого абзаца
+% \renewcommand{\baselinestretch}{1.25}
+
+\newcommand{\sfs}{}
+% \sfs % размер шрифта и расстояния между строками
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%\input{userstyles}          % Стили для специфических пользовательских задач
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%\input{../biblio/bibliopreamble}% Настройки библиографии из внешнего файла (там же выбор: встроенная или на основе biblatex)
+%%% Библиография. Общие настройки для двух способов её подключения %%%
+
+
+%%% Выбор реализации %%%
+% \ifthenelse{\equal{\thebibliosel}{0}}{%
+%     \input{../biblio/predefined}  % Встроенная реализация с загрузкой файла через движок bibtex8
+% }{
+%    \input{../biblio/biblatex}    % Реализация пакетом biblatex через движок biber
+%%% Реализация библиографии пакетами biblatex и biblatex-gost с использованием движка biber %%%
+
+%\usepackage{csquotes} % biblatex рекомендует его подключать. Пакет для оформления сложных блоков цитирования.
+
+%%% Загрузка пакета с основными настройками %%%
+\usepackage[%
+backend=biber,% движок
+bibencoding=utf8,% кодировка bib файла
+% sorting=none,% настройка сортировки списка литературы
+% style=gost-numeric,% стиль цитирования и библиографии (по ГОСТ)
+% language=autobib,% получение языка из babel/polyglossia, default:
+%                  % autobib % если ставить autocite или auto, то цитаты
+%                  % в тексте с указанием страницы, получат указание
+%                  % страницы на языке оригинала
+% autolang=other,% многоязычная библиография
+% clearlang=true,% внутренний сброс поля language, если он совпадает с
+%                % языком из babel/polyglossia
+% defernumbers=true,% нумерация проставляется после двух компиляций,
+%                   % зато позволяет выцеплять библиографию по ключевым
+%                   % словам и нумеровать не из большего списка
+% sortcites=true,% сортировать номера затекстовых ссылок при цитировании
+%                % (если в квадратных скобках несколько ссылок, то
+%                % отображаться будут отсортированно, а не абы как)
+%doi=false,% Показывать или нет ссылки на DOI
+%isbn=false,% Показывать или нет ISBN
+]{biblatex}
+
+
+
+%http://tex.stackexchange.com/a/141831/79756
+%There is a way to automatically map the language field to the langid field. The following lines in the preamble should be enough to do that.
+%This command will copy the language field into the langid field and will then delete the contents of the language field. The language field will only be deleted if it was successfully copied into the langid field.
+\DeclareSourcemap{ %модификация bib файла перед тем, как им займётся biblatex 
+    \maps{
+        % \map{% перекидываем значения полей language в поля langid, которыми пользуется biblatex
+        %     \step[fieldsource=language, fieldset=langid, origfieldval, final]
+        %     \step[fieldset=language, null]
+        % }
+        % \map{% перекидываем значения полей numpages в поля pagetotal, которыми пользуется biblatex
+        %     \step[fieldsource=numpages, fieldset=pagetotal, origfieldval, final]
+        %     \step[fieldset=pagestotal, null]
+        % }
+        % \map{% если в поле medium написано "Электронный ресурс", то устанавливаем поле media. которым пользуется biblatex в значение eresource
+        %     \step[fieldsource=medium,
+        %     match=\regexp{Электронный\s+ресурс},
+        %     final]
+        %     \step[fieldset=media, fieldvalue=eresource]
+        % }
+        % \map[overwrite]{% стираем значения всех полей issn
+        %     \step[fieldset=issn, null]
+        % }
+        % \map[overwrite]{% стираем значения всех полей abstract, поскольку ими не пользуемся, а там бывают "неприятные" латеху символы
+        %     \step[fieldsource=abstract]
+        %     \step[fieldset=abstract,null]
+        % }
+        % \map[overwrite]{ % переделка формата записи даты
+        %     \step[fieldsource=urldate,
+        %     match=\regexp{([0-9]{2})\.([0-9]{2})\.([0-9]{4})},
+        %     replace={$3-$2-$1$4}, % $4 вставлен исключительно ради нормальной работы программ подсветки синтаксиса, которые некорректно обрабатывают $ в таких конструкциях
+        %     final]
+        % }
+        \map[overwrite]{ % добавляем ключевые слова, чтобы различать источники
+            \perdatasource{../biblio/othercites.bib}
+            \step[fieldset=keywords, fieldvalue={biblioother,bibliofull}]
+        }
+        \map[overwrite]{ % добавляем ключевые слова, чтобы различать источники
+            \perdatasource{../biblio/authorpapersVAK.bib}
+            \step[fieldset=keywords, fieldvalue={biblioauthorvak,biblioauthor,bibliofull}]
+        }
+        \map[overwrite]{ % добавляем ключевые слова, чтобы различать источники
+            \perdatasource{../biblio/authorpapers.bib}
+            \step[fieldset=keywords, fieldvalue={biblioauthornotvak,biblioauthor,bibliofull}]
+        }
+        \map[overwrite]{ % добавляем ключевые слова, чтобы различать источники
+            \perdatasource{../biblio/authorconferences.bib}
+            \step[fieldset=keywords, fieldvalue={biblioauthorconf,biblioauthor,bibliofull}]
+        }
+%        \map[overwrite]{% стираем значения всех полей series
+%            \step[fieldset=series, null]
+%        }
+        \map[overwrite]{% перекидываем значения полей howpublished в поля organization для типа online
+            \step[typesource=online, fieldsource=howpublished, fieldset=organization, origfieldval, final]
+            \step[fieldset=howpublished, null]
+        }
+        % Так отключаем [Электронный ресурс]
+%        \map[overwrite]{% стираем значения всех полей media=eresource
+%            \step[fieldsource=media,
+%            match={eresource},
+%            final]
+%            \step[fieldset=media, null]
+%        }
+    }
+}
+
+%%% Правка записей типа thesis, чтобы дважды не писался автор
+%\DeclareBibliographyDriver{thesis}{%
+%  \usebibmacro{bibindex}%
+%  \usebibmacro{begentry}%
+%  \usebibmacro{heading}%
+%  \newunit
+%  \usebibmacro{author}%
+%  \setunit*{\labelnamepunct}%
+%  \usebibmacro{thesistitle}%
+%  \setunit{\respdelim}%
+%  %\printnames[last-first:full]{author}%Вот эту строчку нужно убрать, чтобы автор диссертации не дублировался
+%  \newunit\newblock
+%  \printlist[semicolondelim]{specdata}%
+%  \newunit
+%  \usebibmacro{institution+location+date}%
+%  \newunit\newblock
+%  \usebibmacro{chapter+pages}%
+%  \newunit
+%  \printfield{pagetotal}%
+%  \newunit\newblock
+%  \usebibmacro{doi+eprint+url+note}%
+%  \newunit\newblock
+%  \usebibmacro{addendum+pubstate}%
+%  \setunit{\bibpagerefpunct}\newblock
+%  \usebibmacro{pageref}%
+%  \newunit\newblock
+%  \usebibmacro{related:init}%
+%  \usebibmacro{related}%
+%  \usebibmacro{finentry}}
+
+
+%\newbibmacro{string+doi}[1]{% новая макрокоманда на простановку ссылки на doi
+%    \iffieldundef{doi}{#1}{\href{http://dx.doi.org/\thefield{doi}}{#1}}}
+%
+%\renewcommand*{\mkgostheading}[1]{\usebibmacro{string+doi}{#1}} % ссылка на doi с авторов. стоящих впереди записи
+%\renewcommand*{\mkgostheading}[1]{#1} % только лишь убираем курсив с авторов
+%\DeclareFieldFormat{title}{\usebibmacro{string+doi}{#1}} % ссылка на doi с названия работы
+%\DeclareFieldFormat{journaltitle}{\usebibmacro{string+doi}{#1}} % ссылка на doi с названия журнала
+% Убрать тире из разделителей элементов в библиографии:
+%\renewcommand*{\newblockpunct}{%
+%    \addperiod\space\bibsentence}%block punct.,\bibsentence is for vol,etc.
+
+%%% Возвращаем запись «Режим доступа» %%%
+%\DefineBibliographyStrings{english}{%
+%    urlfrom = {Mode of access}
+%}
+%\DeclareFieldFormat{url}{\bibstring{urlfrom}\addcolon\space\url{#1}}
+
+%%% Set low penalties for breaks at uppercase letters and lowercase letters
+%\setcounter{biburllcpenalty}{500} %управляет разрывами ссылок после маленьких букв RTFM biburllcpenalty
+%\setcounter{biburlucpenalty}{3000} %управляет разрывами ссылок после больших букв, RTFM biburlucpenalty
+
+%%% Список литературы с красной строки (без висячего отступа) %%%
+%\defbibenvironment{bibliography} % переопределяем окружение библиографии из gost-numeric.bbx пакета biblatex-gost
+%  {\list
+%     {\printtext[labelnumberwidth]{%
+%	\printfield{prefixnumber}%
+%	\printfield{labelnumber}}}
+%     {%
+%      \setlength{\labelwidth}{\labelnumberwidth}%
+%      \setlength{\leftmargin}{0pt}% default is \labelwidth
+%      \setlength{\labelsep}{\widthof{\ }}% Управляет длиной отступа после точки % default is \biblabelsep
+%      \setlength{\itemsep}{\bibitemsep}% Управление дополнительным вертикальным разрывом между записями. \bibitemsep по умолчанию соответствует \itemsep списков в документе.
+%      \setlength{\itemindent}{\bibhang}% Пользуемся тем, что \bibhang по умолчанию принимает значение \parindent (абзацного отступа), который переназначен в styles.tex
+%      \addtolength{\itemindent}{\labelwidth}% Сдвигаем правее на величину номера с точкой
+%      \addtolength{\itemindent}{\labelsep}% Сдвигаем ещё правее на отступ после точки
+%      \setlength{\parsep}{\bibparsep}%
+%     }%
+%      \renewcommand*{\makelabel}[1]{\hss##1}%
+%  }
+%  {\endlist}
+%  {\item}
+
+%%% Подключение файлов bib %%%
+\addbibresource{../biblio/othercites.bib}
+\addbibresource{../biblio/authorpapersVAK.bib}
+\addbibresource{../biblio/authorpapers.bib}
+\addbibresource{../biblio/authorconferences.bib}
+
+
+%% Счётчик использованных ссылок на литературу, обрабатывающий с учётом неоднократных ссылок
+%http://tex.stackexchange.com/a/66851/79756
+%\newcounter{citenum}
+\newtotcounter{citenum}
+\makeatletter
+\defbibenvironment{counter} %Env of bibliography
+  {\setcounter{citenum}{0}%
+  \renewcommand{\blx@driver}[1]{}%
+  } %what is doing at the beginining of bibliography. In your case it's : a. Reset counter b. Say to print nothing when a entry is tested.
+  {} %Здесь то, что будет выводиться командой \printbibliography. \thecitenum сюда писать не надо
+  {\stepcounter{citenum}} %What is printing / executed at each entry.
+\makeatother
+\defbibheading{counter}{}
+
+
+
+\newtotcounter{citeauthorvak}
+\makeatletter
+\defbibenvironment{countauthorvak} %Env of bibliography
+{\setcounter{citeauthorvak}{0}%
+    \renewcommand{\blx@driver}[1]{}%
+} %what is doing at the beginining of bibliography. In your case it's : a. Reset counter b. Say to print nothing when a entry is tested.
+{} %Здесь то, что будет выводиться командой \printbibliography. Обойдёмся без \theciteauthorvak в нашей реализации
+{\stepcounter{citeauthorvak}} %What is printing / executed at each entry.
+\makeatother
+\defbibheading{countauthorvak}{}
+
+\newtotcounter{citeauthornotvak}
+\makeatletter
+\defbibenvironment{countauthornotvak} %Env of bibliography
+{\setcounter{citeauthornotvak}{0}%
+    \renewcommand{\blx@driver}[1]{}%
+} %what is doing at the beginining of bibliography. In your case it's : a. Reset counter b. Say to print nothing when a entry is tested.
+{} %Здесь то, что будет выводиться командой \printbibliography. Обойдёмся без \theciteauthornotvak в нашей реализации
+{\stepcounter{citeauthornotvak}} %What is printing / executed at each entry.
+\makeatother
+\defbibheading{countauthornotvak}{}
+
+\newtotcounter{citeauthorconf}
+\makeatletter
+\defbibenvironment{countauthorconf} %Env of bibliography
+{\setcounter{citeauthorconf}{0}%
+    \renewcommand{\blx@driver}[1]{}%
+} %what is doing at the beginining of bibliography. In your case it's : a. Reset counter b. Say to print nothing when a entry is tested.
+{} %Здесь то, что будет выводиться командой \printbibliography. Обойдёмся без \theciteauthorconf в нашей реализации
+{\stepcounter{citeauthorconf}} %What is printing / executed at each entry.
+\makeatother
+\defbibheading{countauthorconf}{}
+
+\newtotcounter{citeauthor}
+\makeatletter
+\defbibenvironment{countauthor} %Env of bibliography
+{\setcounter{citeauthor}{0}%
+    \renewcommand{\blx@driver}[1]{}%
+} %what is doing at the beginining of bibliography. In your case it's : a. Reset counter b. Say to print nothing when a entry is tested.
+{} %Здесь то, что будет выводиться командой \printbibliography. Обойдёмся без \theciteauthor в нашей реализации
+{\stepcounter{citeauthor}} %What is printing / executed at each entry.
+\makeatother
+\defbibheading{countauthor}{}
+
+
+
+
+
+%%% Создание команд для вывода списка литературы %%%
+\newcommand*{\insertbibliofull}{
+\printbibliography[keyword=bibliofull,section=0]
+\printbibliography[heading=counter,env=counter,keyword=bibliofull,section=0]
+}
+
+\newcommand*{\insertbiblioauthor}{
+\printbibliography[keyword=biblioauthor,section=1,title=\authorbibtitle]
+\printbibliography[heading=counter,env=counter,keyword=biblioauthor,section=1]
+}
+
+\newcommand*{\insertbiblioother}{
+\printbibliography[keyword=biblioother]
+\printbibliography[heading=counter,env=counter,keyword=biblioother]
+}
+
+
+%}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\begin{document}
+
+\input{title}           % Титульный лист
+\input{content}         % Содержание автореферата
+
+\end{document}


### PR DESCRIPTION
Сильно порезаный шаблон ради скорости сборки. Только для автореферата. Надо, наверное, его еще дорабатывать, может что-то можно обратно включить, что не очень увеличивает время сборки, но заметно улучает черновик визуально. В целом процедура была проста - все внешние include перетащил  в draft.pdf, далее всё, что можно было закоментить - коментил. Если комментирование чего-то вызвало ошибку сборки - либло разкоментил, либо переопределял комманду).

 Для текущей версии у меня на машине (всё с biber) - улучшение относительно исходного варианта - почти в 5 раз:

diser/Synopsis$ rm -rf *.pdf && make distclean && time make
чистовик xelatex ~ 11.5 сек.

diser/Synopsis$ rm -rf *.pdf && make distclean && time make pdf
чистовик pdflatex ~ 9.5 cек.

diser/Synopsis$ rm -rf *.pdf && make distclean && time make xedraft
черновик xelatex ~ 4.6 сек.

diser/Synopsis$ rm -rf *.pdf && make distclean && time make draft
черновик pdflatex ~2.5 сек.