### PR TITLE
Проверять наличие \thedraft для условной компиляции

### DIFF
--- a/common/setup.tex
+++ b/common/setup.tex
@@ -1,11 +1,15 @@
 %% Режим черновика
-\newcounter{draft}
-\setcounter{draft}{0}  % 0 --- чистовик (максимальное соблюдение ГОСТ)
+\makeatletter
+\@ifundefined{c@draft}{
+  \newcounter{draft}
+  \setcounter{draft}{0}  % 0 --- чистовик (максимальное соблюдение ГОСТ)
                          % 1 --- черновик (отклонения от ГОСТ, но быстрая сборка итоговых PDF)
+}{}
+\makeatother
 
 %% Библиография
 
 %% Внимание! При использовании bibtex8 необходимо удалить все
-%% цитирования из  ../common/characteristic.tex 
+%% цитирования из  ../common/characteristic.tex
 \newcounter{bibliosel}
 \setcounter{bibliosel}{1}           % 0 --- встроенная реализация с загрузкой файла через движок bibtex8; 1 --- реализация пакетом biblatex через движок biber


### PR DESCRIPTION
Использовать latexmk для сборки удобно, но ещё удобнее не вносить правки в код для включения режима черновика:

* `latexmk -pdf -pdflatex="pdflatex %O '\newcounter{draft}\setcounter{draft}{1}\input{%S}'" -silent dissertation` для черновой сборки;
* `latexmk -pdf -pdflatex="xelatex %O %S" -silent dissertation` для чистовой сборки.

Чтобы такая возможность работала, нужно убедиться, что переменная `\thedraft` определена корректно. Для этого введена соответствующая проверка.