### PR TITLE
Удаление УДК с титульной страницы

### DIFF
--- a/Dissertation/title.tex
+++ b/Dissertation/title.tex
@@ -14,14 +14,14 @@
   \begin{minipage}[b]{0.499\linewidth}
     \begin{flushright}%
       На правах рукописи\\
-      \textsl {УДК \thesisUdk}
+%      \textsl {УДК \thesisUdk}
     \end{flushright}%
   \end{minipage}
 }{
 \begin{flushright}%
 На правах рукописи
 
-\textsl {УДК \thesisUdk}
+%\textsl {УДК \thesisUdk}
 \end{flushright}%
 }
 %

--- a/common/data.tex
+++ b/common/data.tex
@@ -10,8 +10,8 @@
 \newcommand{\thesisAuthorShort}        % Диссертация, ФИО автора инициалами
 {\todo{И.О.~Фамилия}}
 
-\newcommand{\thesisUdk}                % Диссертация, УДК
-{\todo{xxx.xxx}}
+%\newcommand{\thesisUdk}                % Диссертация, УДК
+%{\todo{xxx.xxx}}
 \newcommand{\thesisTitle}              % Диссертация, название
 {\texorpdfstring{\todo{\MakeUppercase{Название диссертационной работы}}}{Название диссертационной работы}}
 \newcommand{\thesisSpecialtyNumber}    % Диссертация, специальность, номер


### PR DESCRIPTION
Код, отвечающий за вывод УДК, закомментирован.
УДК указывать не требуется ни по ГОСТ 7.0.11,
ни по рекомендованному оформлению титульной страницы
из приложения к Положению о совете по защите диссертаций.

Добавление УДК [идёт по-видимому](https://github.com/latex-g7-32/latex-g7-32/issues/50#issuecomment-300282685) с времён использования ГОСТ 7.32 для оформления диссертаций за неимением иного.