### PR TITLE
Обновление .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,7 @@ images/* linguist-vendored
 PSCyr/pscyr0.4d.zip linguist-vendored
 Documents/* linguist-documentation
 *.md linguist-documentation
+.gitattributes export-ignore
+.gitignore export-ignore
+LICENSE export-ignore
+CONTRIBUTING.md export-ignore


### PR DESCRIPTION
В результате в архивах с релизами не появятся:
.gitattributes
.gitignore
LICENSE
CONTRIBUTING.md

Посмотреть, что попадает в архив возможно следующей командой:
`git archive --format=zip -o test.zip HEAD`