### PR TITLE
Контроль подключения пакета pscyr

### DIFF
--- a/common/packages.tex
+++ b/common/packages.tex
@@ -38,15 +38,19 @@
     \usepackage{polyglossia}[2014/05/21]            % Поддержка многоязычности (fontspec подгружается автоматически)
 \else
    %%% Решение проблемы копирования текста в буфер кракозябрами
-    \IfFileExists{pscyr.sty}{% вероятно, без pscyr нет необходимости в этом коде
-        \input glyphtounicode.tex
-        \input glyphtounicode-cmr.tex %from pdfx package
-        \pdfgentounicode=1
+    \ifnumequal{\value{usepscyr}}{1}{% Используется pscyr, при наличии
+        \IfFileExists{pscyr.sty}{% вероятно, без pscyr нет необходимости в этом коде
+            \input glyphtounicode.tex
+            \input glyphtounicode-cmr.tex %from pdfx package
+            \pdfgentounicode=1
+        }{}
     }{}
     \usepackage{cmap}                               % Улучшенный поиск русских слов в полученном pdf-файле
     \defaulthyphenchar=127                          % Если стоит до fontenc, то переносы не впишутся в выделяемый текст при копировании его в буфер обмена 
     \usepackage[T1,T2A]{fontenc}                    % Поддержка русских букв
-    \IfFileExists{pscyr.sty}{\usepackage{pscyr}}{}  % Красивые русские шрифты
+    \ifnumequal{\value{usepscyr}}{1}{% Используется pscyr, при наличии
+        \IfFileExists{pscyr.sty}{\usepackage{pscyr}}{}  % Подключение pscyr
+    }{}
     \usepackage[utf8]{inputenc}[2014/04/30]         % Кодировка utf8
     \usepackage[english, russian]{babel}[2014/03/24]% Языки: русский, английский
 \fi

--- a/common/setup.tex
+++ b/common/setup.tex
@@ -7,6 +7,15 @@
 }{}
 \makeatother
 
+%% Использование пакета pscyr, при его наличии
+\makeatletter
+\@ifundefined{c@usepscyr}{
+  \newcounter{usepscyr}
+  \setcounter{usepscyr}{1}  % 0 --- не использовать пакет pscyr
+                            % 1 --- использовать пакет pscyr, при его наличии 
+}{}
+\makeatother
+
 %% Библиография
 
 %% Внимание! При использовании bibtex8 необходимо удалить все

--- a/common/styles.tex
+++ b/common/styles.tex
@@ -16,7 +16,9 @@
     \setsansfont{Arial}                              % Шрифт без засечек
     \newfontfamily\cyrillicfontsf{Arial}             % Шрифт без засечек для кириллицы
 \else
-    \IfFileExists{pscyr.sty}{\renewcommand{\rmdefault}{ftm}}{}
+    \ifnumequal{\value{usepscyr}}{1}{% Используется pscyr, при наличии
+        \IfFileExists{pscyr.sty}{\renewcommand{\rmdefault}{ftm}}{}
+    }{}
 \fi
 
 %%% Подписи %%%


### PR DESCRIPTION
Заведён ключ. позволяющий отключить использование pscyr
даже при корректной установке этого пакета.
Также появляется возможность управлять включением pscyr через Makefile.