### PR TITLE
Feature/spellcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,7 +282,7 @@ ifdef DICT_EXTRA
 endif
 
 spell-check:
-	for file in $(SPELLCHECK_FILES); do \
+	@for file in $(SPELLCHECK_FILES); do \
 		aspell --lang=$(LANG) $(SDICT_DIR) $(SDICT_MAIN) $(SDICT_EXTRA) --mode=tex --ignore-case check $$file; \
 	done;
 

--- a/Makefile
+++ b/Makefile
@@ -261,6 +261,32 @@ clean:
 	rm -f synopsis.bbl
 	$(MAKE) clean -C Presentation
 
+
+SPELLCHECK_DIRS ?= Dissertation Presentation Synopsis
+SPELLCHECK_FILES ?= $(foreach dir,$(SPELLCHECK_DIRS),$(wildcard $(dir)/*.tex))
+SPELLCHECK_LANG ?= ru
+DICT_DIR ?=
+DICT_MAIN ?=
+DICT_EXTRA ?=
+
+ifdef DICT_DIR
+    SDICT_DIR := --dict-dir=$(DICT_DIR)
+endif
+
+ifdef DICT_MAIN
+    SDICT_MAIN := --master=$(DICT_MAIN)
+endif
+
+ifdef DICT_EXTRA
+    SDICT_EXTRA := --extra-dicts=$(DICT_EXTRA)
+endif
+
+spell-check:
+	for file in $(SPELLCHECK_FILES); do \
+		aspell --lang=$(LANG) $(SDICT_DIR) $(SDICT_MAIN) $(SDICT_EXTRA) --mode=tex --ignore-case check $$file; \
+	done;
+
+
 distclean:
 	$(MAKE) distclean -C Dissertation
 	$(MAKE) distclean -C Synopsis


### PR DESCRIPTION
Добавлен рецепт для интерактивной проверки правописания в `Makefile`. Для проверки используется программа `GNU aspell`. 
На `debian` программа `GNU aspell` доступна в пакетах `aspell`; в пакете `aspell-ru` лежит русский словарь.
По умолчанию рецепт запускает `aspell` для каждого файла с расширением `.tex` в папках `Dissertation`, `Presentation` и  `Synopsis`.  Папки можно выбирать путём задания переменной `SPELLCHECK_DIRS`. Отдельные файлы можно выбрать путём задания переменной `SPELLCHECK_FILES`. По умолчанию используется русский язык.