### PR TITLE
Замена шрифтов на семейство Liberation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,36 @@
-.PHONY: synopsis dissertation preformat pdflatex talk dissertation-preformat dissertation-formated synopsis-preformat pdflatex-examples altfont2-examples pscyr-examples xelatex-examples lualatex-examples examples spell-check indent clean distclean release draft
+.PHONY: synopsis dissertation preformat pdflatex talk dissertation-preformat\
+dissertation-formated synopsis-preformat pdflatex-examples altfont2-examples\
+pscyr-examples xelatex-examples lualatex-examples examples spell-check indent\
+clean distclean release draft
 
 all: synopsis dissertation
 
 preformat: synopsis-preformat dissertation-preformat
 
+ifneq ($(SystemDrive),)
+    FONT_FAMILY?=1
+else
+    FONT_FAMILY?=2
+endif
+
 dissertation:
 	#	$(MAKE) -C Dissertation
-	latexmk -pdf -pdflatex="xelatex %O %S" dissertation
+	latexmk -pdf -pdflatex="xelatex %O '\newcounter{fontfamily}\setcounter{fontfamily}\
+{$(FONT_FAMILY)}\input{%S}'" dissertation
 
 pdflatex:
 	latexmk -pdf -pdflatex="pdflatex %O %S" dissertation
 
 synopsis:
 	#	$(MAKE) -C Synopsis
-	latexmk -pdf -pdflatex="xelatex %O %S" synopsis
+	latexmk -pdf -pdflatex="xelatex %O '\newcounter{fontfamily}\setcounter{fontfamily}\
+{$(FONT_FAMILY)}\input{%S}'" synopsis
+
 draft:	
-	latexmk -pdf -pdflatex="xelatex %O '\newcounter{draft}\setcounter{draft}{1}\input{%S}'" dissertation
-	latexmk -pdf -pdflatex="xelatex %O '\newcounter{draft}\setcounter{draft}{1}\input{%S}'" synopsis
+	latexmk -pdf -pdflatex="xelatex %O '\newcounter{fontfamily}\setcounter{fontfamily}\
+{$(FONT_FAMILY)}\newcounter{draft}\setcounter{draft}{1}\input{%S}'" dissertation
+	latexmk -pdf -pdflatex="xelatex %O '\newcounter{fontfamily}\setcounter{fontfamily}\
+{$(FONT_FAMILY)}\newcounter{draft}\setcounter{draft}{1}\input{%S}'" synopsis
 
 talk:
 	$(MAKE) talk -C Presentation

--- a/Readme/Installation.md
+++ b/Readme/Installation.md
@@ -59,13 +59,6 @@ draft`, которая будет собирать в режиме чернов�
 $ sudo apt-get install texlive-xetex texlive-generic-extra texlive-lang-cyrillic latexmk biber
 ```
 
-Для нормальной работы в системе должны быть установлены нужные шрифты. Например, для Ubuntu это можно сделать так:
-
-```
-$ sudo apt-get install ttf-mscorefonts-installer
-$ sudo fc-cache -fv
-```
-
 ### В Fedora
 
 > Протестировано на Fedora 27.
@@ -82,13 +75,6 @@ $ sudo dnf install texlive-xetex latexmk texlive-hyphen-russian biber \
                     texlive-biblatex texlive-biblatex-gost texlive-cite \
                     texlive-bibtex texlive-impnattypo texlive-cleveref \
                     texlive-tabu texlive-mwe
-```
-
-Далее необходимо установить необходимые шрифты из набора [Microsoft's Core Fonts](http://mscorefonts2.sourceforge.net/). Например, так:
-
-```
-$ sudo dnf install http://downloads.sourceforge.net/project/mscorefonts2/rpms/msttcore-fonts-installer-2.6-1.noarch.rpm
-$ sudo fc-cache -fv
 ```
 
 > В Fedora 23 есть проблема ([#84](https://github.com/AndreyAkinshin/Russian-Phd-LaTeX-Dissertation-Template/issues/84)) с компиляцией библиографии с помощью `biblatex` и `biber`, поэтому необходимо переключиться на использование `bibtex`. Для этого в файле `Dissertation/setup.tex` переключите `\setcounter{bibliosel}{1}` в `0`, чтобы получилось `\setcounter{bibliosel}{0}`. Туже самую операцию повторите в файле `Synopsis/setup.tex`.

--- a/common/fonts.tex
+++ b/common/fonts.tex
@@ -1,0 +1,47 @@
+%%% Кодировки и шрифты %%%
+\ifxetexorluatex
+    \setmainlanguage[babelshorthands=true]{russian}    % Язык по-умолчанию русский с поддержкой приятных команд пакета babel
+    \setotherlanguage{english}                         % Дополнительный язык = английский (в американской вариации по-умолчанию)
+    \defaultfontfeatures{Ligatures=TeX}                % стандартные лигатуры TeX, замены нескольких дефисов на тире и т. п. Настройки моноширинного шрифта должны идти до этой строки, чтобы при врезках кода программ в коде не применялись лигатуры и замены дефисов
+
+    \ifxetexorluatex                                   % Проверка существования шрифтов. Не доступна в pdflatex
+        \ifnumequal{\value{fontfamily}}{1}{
+            \IfFontExistsTF{Times New Roman}{}{\setcounter{fontfamily}{0}}
+        }{}
+        \ifnumequal{\value{fontfamily}}{2}{
+            \IfFontExistsTF{LiberationSerif}{}{\setcounter{fontfamily}{0}}
+        }{}
+    \fi
+
+    \ifnumequal{\value{fontfamily}}{0}{                    % Семейство шрифтов CMU. Используется как fallback
+        \setmonofont{CMU Typewriter Text}                  % моноширинный шрифт
+        \newfontfamily\cyrillicfonttt{CMU Typewriter Text} % моноширинный шрифт для кириллицы
+        \setmainfont{CMU Serif}                            % Шрифт с засечками
+        \newfontfamily\cyrillicfont{CMU Serif}             % Шрифт с засечками для кириллицы
+        \setsansfont{CMU Sans Serif}                       % Шрифт без засечек
+        \newfontfamily\cyrillicfontsf{CMU Sans Serif}      % Шрифт без засечек для кириллицы
+    }
+
+    \ifnumequal{\value{fontfamily}}{1}{                    % Семейство MS шрифтов
+        \setmonofont{Courier New}                          % моноширинный шрифт
+        \newfontfamily\cyrillicfonttt{Courier New}         % моноширинный шрифт для кириллицы
+        \setmainfont{Times New Roman}                      % Шрифт с засечками
+        \newfontfamily\cyrillicfont{Times New Roman}       % Шрифт с засечками для кириллицы
+        \setsansfont{Arial}                                % Шрифт без засечек
+        \newfontfamily\cyrillicfontsf{Arial}               % Шрифт без засечек для кириллицы
+    }
+
+    \ifnumequal{\value{fontfamily}}{2}{                    % Семейство шрифтов Liberation
+        \setmonofont{LiberationMono}                       % моноширинный шрифт
+        \newfontfamily\cyrillicfonttt{LiberationMono}      % моноширинный шрифт для кириллицы
+        \setmainfont{LiberationSerif}                      % Шрифт с засечками
+        \newfontfamily\cyrillicfont{LiberationSerif}       % Шрифт с засечками для кириллицы
+        \setsansfont{LiberationSans}                       % Шрифт без засечек
+        \newfontfamily\cyrillicfontsf{LiberationSans}      % Шрифт без засечек для кириллицы
+    }
+
+\else
+    \ifnumequal{\value{usealtfont}}{1}{% Используется pscyr, при наличии
+        \IfFileExists{pscyr.sty}{\renewcommand{\rmdefault}{ftm}}{}
+    }{}
+\fi

--- a/common/setup.tex
+++ b/common/setup.tex
@@ -17,6 +17,16 @@
 }{}
 \makeatother
 
+%%% Использование в xelatex и lualatex семейств шрифтов %%%
+\makeatletter
+\@ifundefined{c@fontfamily}{
+  \newcounter{fontfamily}
+  \setcounter{fontfamily}{0}   % 0 --- CMU семейство. Используется как fallback;
+                              % 1 --- Ширфты от MS (Times New Roman и компания)
+                              % 2 --- Семейство Liberation
+}{}
+\makeatother
+
 %% Библиография
 
 %% Внимание! При использовании bibtex8 необходимо удалить все

--- a/common/styles.tex
+++ b/common/styles.tex
@@ -8,13 +8,13 @@
 \ifxetexorluatex
     \setmainlanguage[babelshorthands=true]{russian}  % Язык по-умолчанию русский с поддержкой приятных команд пакета babel
     \setotherlanguage{english}                       % Дополнительный язык = английский (в американской вариации по-умолчанию)
-    \setmonofont{Courier New}                        % моноширинный шрифт
-    \newfontfamily\cyrillicfonttt{Courier New}       % моноширинный шрифт для кириллицы
+    \setmonofont{LiberationMono}                     % моноширинный шрифт
+    \newfontfamily\cyrillicfonttt{LiberationMono}    % моноширинный шрифт для кириллицы
     \defaultfontfeatures{Ligatures=TeX}              % стандартные лигатуры TeX, замены нескольких дефисов на тире и т. п. Настройки моноширинного шрифта должны идти до этой строки, чтобы при врезках кода программ в коде не применялись лигатуры и замены дефисов
-    \setmainfont{Times New Roman}                    % Шрифт с засечками
-    \newfontfamily\cyrillicfont{Times New Roman}     % Шрифт с засечками для кириллицы
-    \setsansfont{Arial}                              % Шрифт без засечек
-    \newfontfamily\cyrillicfontsf{Arial}             % Шрифт без засечек для кириллицы
+    \setmainfont{LiberationSerif}                    % Шрифт с засечками
+    \newfontfamily\cyrillicfont{LiberationSerif}     % Шрифт с засечками для кириллицы
+    \setsansfont{LiberationSans}                     % Шрифт без засечек
+    \newfontfamily\cyrillicfontsf{LiberationSans}    % Шрифт без засечек для кириллицы
 \else
     \ifnumequal{\value{usealtfont}}{1}{% Используется pscyr, при наличии
         \IfFileExists{pscyr.sty}{\renewcommand{\rmdefault}{ftm}}{}

--- a/common/styles.tex
+++ b/common/styles.tex
@@ -5,21 +5,8 @@
 }
 
 %%% Кодировки и шрифты %%%
-\ifxetexorluatex
-    \setmainlanguage[babelshorthands=true]{russian}  % Язык по-умолчанию русский с поддержкой приятных команд пакета babel
-    \setotherlanguage{english}                       % Дополнительный язык = английский (в американской вариации по-умолчанию)
-    \setmonofont{LiberationMono}                     % моноширинный шрифт
-    \newfontfamily\cyrillicfonttt{LiberationMono}    % моноширинный шрифт для кириллицы
-    \defaultfontfeatures{Ligatures=TeX}              % стандартные лигатуры TeX, замены нескольких дефисов на тире и т. п. Настройки моноширинного шрифта должны идти до этой строки, чтобы при врезках кода программ в коде не применялись лигатуры и замены дефисов
-    \setmainfont{LiberationSerif}                    % Шрифт с засечками
-    \newfontfamily\cyrillicfont{LiberationSerif}     % Шрифт с засечками для кириллицы
-    \setsansfont{LiberationSans}                     % Шрифт без засечек
-    \newfontfamily\cyrillicfontsf{LiberationSans}    % Шрифт без засечек для кириллицы
-\else
-    \ifnumequal{\value{usealtfont}}{1}{% Используется pscyr, при наличии
-        \IfFileExists{pscyr.sty}{\renewcommand{\rmdefault}{ftm}}{}
-    }{}
-\fi
+% Опеределение шрифтов в файле common/fonts.tex
+\input{common/fonts}
 
 %%% Подписи %%%
 \setlength{\abovecaptionskip}{0pt}   % Отбивка над подписью


### PR DESCRIPTION
Шрифты семейства [liberation](https://pagure.io/liberation-fonts) метрически совместимы со шрифтами от ms.
Замена позволит упростить установку - эти шрифты предустановлены в большинстве дистрибутивов. Также они распространяются под свободной лицензией. 