### PR TITLE
Автоматическое выравнивание кода при помощи latexindent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,7 @@ pythontex-files-*/
 .Trashes
 ehthumbs.db
 Thumbs.db
+
+# latexindent backups
+*.bak
+*.bak[0-9]

--- a/Dissertation/Makefile
+++ b/Dissertation/Makefile
@@ -192,3 +192,6 @@ distclean:
 	rm -f *.bak
 	rm -f *.bcf
 	rm -f *.run.xml
+
+	# latexindent backup
+	rm -f *.bak[0-9]

--- a/Makefile
+++ b/Makefile
@@ -280,7 +280,7 @@ INDENT_SETTIGNS ?= indent.yaml
 INDENT_DIRS ?= Dissertation Presentation Synopsis
 INDENT_FILES ?= $(foreach dir,$(INDENT_DIRS),$(wildcard $(dir)/*.tex))
 indent:
-	$(foreach file, $(INDENT_FILES),\
+	@$(foreach file, $(INDENT_FILES),\
 	latexindent -l=$(INDENT_SETTIGNS) -s -w $(file);)
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: synopsis dissertation preformat pdflatex talk dissertation-preformat dissertation-formated synopsis-preformat pdflatex-examples altfont2-examples pscyr-examples xelatex-examples lualatex-examples examples spell-check clean distclean release draft
+.PHONY: synopsis dissertation preformat pdflatex talk dissertation-preformat dissertation-formated synopsis-preformat pdflatex-examples altfont2-examples pscyr-examples xelatex-examples lualatex-examples examples spell-check indent clean distclean release draft
 
 all: synopsis dissertation
 
@@ -273,8 +273,15 @@ endif
 
 spell-check:
 	@for file in $(SPELLCHECK_FILES); do \
-		aspell --lang=$(LANG) $(SDICT_DIR) $(SDICT_MAIN) $(SDICT_EXTRA) --mode=tex --ignore-case check $$file; \
+		aspell --lang=$(SPELLCHECK_LANG) $(SDICT_DIR) $(SDICT_MAIN) $(SDICT_EXTRA) --mode=tex --ignore-case check $$file; \
 	done;
+
+INDENT_SETTIGNS ?= indent.yaml
+INDENT_DIRS ?= Dissertation Presentation Synopsis
+INDENT_FILES ?= $(foreach dir,$(INDENT_DIRS),$(wildcard $(dir)/*.tex))
+indent:
+	$(foreach file, $(INDENT_FILES),\
+	latexindent -l=$(INDENT_SETTIGNS) -s -w $(file);)
 
 clean:
 	#	$(MAKE) clean -C Dissertation

--- a/Makefile
+++ b/Makefile
@@ -272,9 +272,8 @@ ifdef DICT_EXTRA
 endif
 
 spell-check:
-	@for file in $(SPELLCHECK_FILES); do \
-		aspell --lang=$(SPELLCHECK_LANG) $(SDICT_DIR) $(SDICT_MAIN) $(SDICT_EXTRA) --mode=tex --ignore-case check $$file; \
-	done;
+	@$(foreach file, $(SPELLCHECK_FILES),\
+	aspell --lang=$(SPELLCHECK_LANG) $(SDICT_DIR) $(SDICT_MAIN) $(SDICT_EXTRA) --mode=tex --ignore-case check $(file);)
 
 INDENT_SETTIGNS ?= indent.yaml
 INDENT_DIRS ?= Dissertation Presentation Synopsis
@@ -477,6 +476,9 @@ distclean:
 	rm -f *.bak
 	rm -f *.bcf
 	rm -f *.run.xml
+
+	# latexindent backup
+	rm -f *.bak[0-9]
 
 release: all
 	git add dissertation.pdf

--- a/Presentation/Makefile
+++ b/Presentation/Makefile
@@ -197,3 +197,6 @@ distclean:
 	rm -f *.bak
 	rm -f *.bcf
 	rm -f *.run.xml
+
+	# latexindent backup
+	rm -f *.bak[0-9]

--- a/Synopsis/Makefile
+++ b/Synopsis/Makefile
@@ -196,3 +196,6 @@ distclean:
 	rm -f *.bak
 	rm -f *.bcf
 	rm -f *.run.xml
+
+	# latexindent backup
+	rm -f *.bak[0-9]

--- a/indent.yaml
+++ b/indent.yaml
@@ -1,0 +1,21 @@
+maxNumberOfBackUps: 3
+cycleThroughBackUps: 1
+
+commandCodeBlocks:
+    roundParenthesesAllowed: 0
+specialBeginEnd:
+    leftRightRound:
+        begin: '\\left\('
+        end: '\\right\)'
+        lookForThis: 1
+    leftRightSquare:
+        begin: '\\left\['
+        end: '\\right\]'
+        lookForThis: 1
+    leftRightCurly:
+        begin: '\\left\\\{'
+        end: '\\right\\\}'
+        lookForThis: 1
+
+indentRulesGlobal:
+    UnNamedGroupingBracesBrackets: 1


### PR DESCRIPTION
Добавлен рецепт для выравнивания кода в `Makefile` при помощи `latexindent`.
Настройки выравнивания лежат в файле `indent.yaml`
По умолчанию рецепт запускает `latexindent` для каждого файла с расширением `.tex` в папках `Dissertation`, `Presentation` и `Synopsis`. Папки можно выбирать путём задания переменной `INDENT_DIRS`. Отдельные файлы можно выбрать путём задания переменной `INDENT_FILES`.