### PR TITLE
Bugfix: Управление заголовком списка литературы в диссертации

### DIFF
--- a/biblio/biblatex.tex
+++ b/biblio/biblatex.tex
@@ -337,7 +337,7 @@ sorting=none,% настройка сортировки списка литера
 
 %%% Создание команд для вывода списка литературы %%%
 \newcommand*{\insertbibliofull}{
-\printbibliography[keyword=bibliofull,section=0]
+\printbibliography[keyword=bibliofull,section=0,title=\fullbibtitle]
 \printbibliography[heading=counter,env=counter,keyword=bibliofull,section=0]
 }
 


### PR DESCRIPTION
Добавлена совместимость с xelatex|lualatex (точнее с polyglossia).
По наводке #227

Автореферат не затронут, поскольку модифицирован вывод команды \insertbibliofull