### PR TITLE
В презентации добавлен аргумент `utf8` необходимый LuaTex

### DIFF
--- a/presentation.tex
+++ b/presentation.tex
@@ -1,4 +1,4 @@
-\documentclass[14pt, xcolor={dvipsnames, table, hyperref, cmyk}]{beamer}
+\documentclass[14pt, xcolor={dvipsnames, table, hyperref, cmyk}, utf8]{beamer}
 
 
 \input{common/setup}          % общие настройки шаблона


### PR DESCRIPTION
Починка внесённой в GH-248 несовместимости с LuaTex.