### PR TITLE
move all rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,10 @@ LATEXFLAGS ?= -halt-on-error -file-line-error
 LATEXMKFLAGS ?= -silent
 BIBERFLAGS ?= # --fixinits
 REGEXDIRS ?= . Dissertation Synopsis Presentation # distclean dirs
+# Makefile options
 MAKEFLAGS := -s
+.DEFAULT_GOAL := all
+.NOTPARALLEL:
 
 export DRAFTON
 export FONTFAMILY
@@ -116,9 +119,6 @@ distclean:
 
 # include after "all" rule
 include examples.mk
-
-# disable parallel build
-.NOTPARALLEL:
 
 .PHONY: all preformat _compile dissertation synopsis \
 presentation dissertation-draft synopsis-draft pdflatex \


### PR DESCRIPTION
Перенесено правило `all` для `make`. В нынешнем состоянии по умолчанию выполняется первое правило из `usercfg.mk`, т.е. `indent`.