### PR TITLE
indent для Widows (просто раскомментирован)

### DIFF
--- a/windows.mk
+++ b/windows.mk
@@ -7,12 +7,12 @@ FONTFAMILY ?= 1 # Используются шрифты семейства MS
 
 ### Пользовательские правила
 
-# INDENT_SETTINGS ?= indent.yaml
-# INDENT_DIRS ?= Dissertation Presentation Synopsis
-# INDENT_FILES ?= $(foreach dir,$(INDENT_DIRS),$(wildcard $(dir)/*.tex))
-# indent:
-# 	@$(foreach file, $(INDENT_FILES),\
-# 	latexindent -l=$(INDENT_SETTINGS) -s -w $(file) &&)\
-# 	echo "done"
+INDENT_SETTINGS ?= indent.yaml
+INDENT_DIRS ?= Dissertation Presentation Synopsis
+INDENT_FILES ?= $(foreach dir,$(INDENT_DIRS),$(wildcard $(dir)/*.tex))
+indent:
+	@$(foreach file, $(INDENT_FILES),\
+	latexindent -l=$(INDENT_SETTINGS) -s -w $(file) &&)\
+	echo "done"
 
 .PHONY: indent


### PR DESCRIPTION
Версия `indent:` для Windows вполне рабочая. [Править](https://github.com/AndreyAkinshin/Russian-Phd-LaTeX-Dissertation-Template/pull/259#issuecomment-473290701), имхо, не требуется - я только раскомментировал.