### PR TITLE
Исправление `compress:` для Windows

### DIFF
--- a/usercfg.mk
+++ b/usercfg.mk
@@ -36,6 +36,6 @@ COMPRESSION_FLAGS += -dMonoImageDownsampleType=/Subsample -dMonoImageResolution=
 
 compress: $(COMPRESS_FILE)
 	ps2pdf14 $(COMPRESSION_FLAGS) -dPDFSETTINGS=/$(COMPRESSION_LEVEL) \
-	-sOutputFile=$(patsubst %.pdf,%_compressed.pdf,$^) $^
+	$^ $(patsubst %.pdf,%_compressed.pdf,$^)
 
 .PHONY: compress


### PR DESCRIPTION
Исправление `compress:` для Windows.

Было так:
```
>gnuwin32-make compress
!Error: no output file specified.

Usage: ps2pdf14 [options] <inputfile> <outputfile>

       <inputfile> can be either a PS, EPS, or PDF file.
       A single hyphen (-) denotes stdin.

       <outputfile> is required if <inputfile> is a PDF file
       or input is read from stdin.
gnuwin32-make: *** [compress] Ошибка 1
```

[Проблем с `/`](https://github.com/AndreyAkinshin/Russian-Phd-LaTeX-Dissertation-Template/pull/259#issuecomment-471678781) я не увидел, но оно хочет именно `ps2pdf [options] input.pdf output.pdf`, а через `-sOutputFile` не хочет. На CentOS7 работает и так и так.