### PR TITLE
fix comments for bibtex

### DIFF
--- a/biblio/othercites.bib
+++ b/biblio/othercites.bib
@@ -140,7 +140,9 @@
 }
 
 % Тот-же пример, с использованием https://www.ctan.org/pkg/biblatex-gost
-% @THESIS{Sirotko,
+% !!! этот пример НЕ работает с bibtex
+% перед использованием добавьте символ at (https://en.wikipedia.org/wiki/At_sign) перед THESIS
+% THESIS{Sirotko,
 %   author =       {Сиротко, Владимир Викторович},
 %   title =        {Медико-социальные аспекты городского травматизма в современных условиях},
 %   media =        {text},
@@ -163,7 +165,9 @@
 }
 
 % Тот-же пример, с использованием https://www.ctan.org/pkg/biblatex-gost
-% @THESIS{Sirotko,
+% !!! этот пример НЕ работает с bibtex
+% перед использованием добавьте символ at (https://en.wikipedia.org/wiki/At_sign) перед THESIS
+% THESIS{Sirotko,
 %   author =       {Лукина, Валентина Александровна},
 %   title =        {Творческая история «Записок охотника» И. С. Тургенева},
 %   media =        {text},
@@ -197,8 +201,10 @@
   language = {russian}
 }
 
+% !!! этот пример НЕ работает с bibtex
+% перед использованием добавьте символ at (https://en.wikipedia.org/wiki/At_sign) перед BOOK
 % Тот-же пример, с использованием https://www.ctan.org/pkg/biblatex-gost
-% @BOOK{Encyclopedia,
+% BOOK{Encyclopedia,
 %   title = {Художественная энциклопедия зарубежного классического искусства},
 %   address = {М.},
 %   media = {eresource},
@@ -219,8 +225,10 @@
   language = {russian}
 }
 
+% !!! этот пример НЕ работает с bibtex
+% перед использованием добавьте символ at (https://en.wikipedia.org/wiki/At_sign) перед BOOK
 % Тот-же пример, с использованием https://www.ctan.org/pkg/biblatex-gost
-% @BOOK{Encyclopedia,
+% BOOK{Encyclopedia,
 %   title = {Художественная энциклопедия зарубежного классического искусства},
 %   address = {М.},
 %   media = {eresource},
@@ -588,7 +596,9 @@ keywords = "Glass ceramic",
 }
 
 % Примеры оформления патентов из пакета https://www.ctan.org/pkg/biblatex-gost
-% @Patent{patent2h,
+% !!! этот пример НЕ работает с bibtex
+% перед использованием добавьте символ at (https://en.wikipedia.org/wiki/At_sign) перед Patent
+% Patent{patent2h,
 %   heading =      {Заявка 1095735 Рос. федерация, МПК\ensuremath{^7} B 64 G 1/00},
 %   author =       {Тернер, Э. В.},
 %   authortype =   {США},
@@ -611,7 +621,9 @@ keywords = "Glass ceramic",
 %   language =     {russian},
 % }
 
-% @Patent{patent3h,
+% !!! этот пример НЕ работает с bibtex
+% перед использованием добавьте символ at (https://en.wikipedia.org/wiki/At_sign) перед Patent
+% Patent{patent3h,
 %   heading =      {А. с. 1007970 СССР, МКИ\ensuremath{^3} В 25.1 15/00},
 %   author =       {В. С. Ваулин and В. Г. Кемайкин},
 %   authortype =   {СССР},
@@ -629,7 +641,9 @@ keywords = "Glass ceramic",
 %   language =     {russian},
 % }
 
-% @Patent{patent2,
+% !!! этот пример НЕ работает с bibtex
+% перед использованием добавьте символ at (https://en.wikipedia.org/wiki/At_sign) перед Patent
+% Patent{patent2,
 %   _heading =     {Заявка 1095735 Рос. федерация},
 %   author =       {Тернер, Э. В.},
 %   authortype =   {США},


### PR DESCRIPTION
Убран символ `@` из комментариев, чтобы не возникало [проблем](https://tex.stackexchange.com/a/21710/104425) с `bibtex`. Подробнее в комментариях к  #282