### PR TITLE
Чиним insertbiblioauthorgrouped

### DIFF
--- a/biblio/biblatex.tex
+++ b/biblio/biblatex.tex
@@ -397,8 +397,8 @@ sorting=none,% настройка сортировки списка литера
 \newcommand*{\insertbiblioauthorgrouped}{% Заготовка для вывода сгруппированных печатных работ автора. Порядок нумерации определяется в соответствующих счетчиках внутри окружения refsection в файле common/characteristic.tex
 \section*{\authorbibtitle}
 \printbibliography[heading=pubsubgroup, keyword=biblioauthorvak, section=1,title=\vakbibtitle]%
-\printbibliography[heading=pubsubgroup, keyword=biblioauthorwos, section=1,title=\vakbibtitle]%
-\printbibliography[heading=pubsubgroup, keyword=biblioauthorscopus, section=1,title=\vakbibtitle]%
+\printbibliography[heading=pubsubgroup, keyword=biblioauthorwos, section=1,title=\wosbibtitle]%
+\printbibliography[heading=pubsubgroup, keyword=biblioauthorscopus, section=1,title=\scopusbibtitle]%
 \printbibliography[heading=pubsubgroup, keyword=biblioauthorconf, section=1,title=\confbibtitle]%
 \printbibliography[heading=pubsubgroup, keyword=biblioauthorothers, section=1,title=\othersbibtitle]%
 }

--- a/common/newnames.tex
+++ b/common/newnames.tex
@@ -30,6 +30,8 @@
 
 \newcommand{\authorbibtitle}{Публикации автора по теме диссертации}
 \newcommand{\vakbibtitle}{В изданиях из списка ВАК РФ}
+\newcommand{\scopusbibtitle}{В изданиях, входящих в международную базу цитирования Scopus}
+\newcommand{\wosbibtitle}{В изданиях, входящих в международную базу цитирования Web of Science}
 \newcommand{\othersbibtitle}{В прочих изданиях}
 \newcommand{\confbibtitle}{В сборниках трудов конференций}
 \newcommand{\fullbibtitle}{Список литературы} % (ГОСТ Р 7.0.11-2011, 4)

--- a/common/newnames.tex
+++ b/common/newnames.tex
@@ -30,6 +30,6 @@
 
 \newcommand{\authorbibtitle}{Публикации автора по теме диссертации}
 \newcommand{\vakbibtitle}{В изданиях из списка ВАК РФ}
-\newcommand{\notvakbibtitle}{В прочих изданиях}
+\newcommand{\othersbibtitle}{В прочих изданиях}
 \newcommand{\confbibtitle}{В сборниках трудов конференций}
 \newcommand{\fullbibtitle}{Список литературы} % (ГОСТ Р 7.0.11-2011, 4)


### PR DESCRIPTION
Чинятся следующие баги из GH-282 :

1. все буквосочетания `notvak` были заменены на `others`, но одно осталось и это ломает `\insertbiblioauthorgrouped`. 
2. В `\insertbiblioauthorgrouped` 3 раза подряд используется заголовок `\vakbibtitle`. (так же косвенно связано с #306)