### PR TITLE
 Косметические изменения в макросах библиографии

### DIFF
--- a/biblio/biblatex.tex
+++ b/biblio/biblatex.tex
@@ -301,7 +301,6 @@ sorting=none,% настройка сортировки списка литера
   {} %Здесь то, что будет выводиться командой \printbibliography. \thecitenum сюда писать не надо
   {\stepcounter{citenum}} %What is printing / executed at each entry.
 \makeatother
-\defbibheading{counter}{}
 
 
 
@@ -314,7 +313,6 @@ sorting=none,% настройка сортировки списка литера
 {} %Здесь то, что будет выводиться командой \printbibliography. Обойдёмся без \theciteauthorvak в нашей реализации
 {\stepcounter{citeauthorvak}} %What is printing / executed at each entry.
 \makeatother
-\defbibheading{countauthorvak}{}
 
 \newtotcounter{citeauthorscopus}
 \makeatletter
@@ -325,7 +323,6 @@ sorting=none,% настройка сортировки списка литера
 {} %Здесь то, что будет выводиться командой \printbibliography. Обойдёмся без \theciteauthorscopus в нашей реализации
 {\stepcounter{citeauthorscopus}} %What is printing / executed at each entry.
 \makeatother
-\defbibheading{countauthorscopus}{}
 
 \newtotcounter{citeauthorwos}
 \makeatletter
@@ -336,7 +333,6 @@ sorting=none,% настройка сортировки списка литера
 {} %Здесь то, что будет выводиться командой \printbibliography. Обойдёмся без \theciteauthorwos в нашей реализации
 {\stepcounter{citeauthorwos}} %What is printing / executed at each entry.
 \makeatother
-\defbibheading{countauthorwos}{}
 
 % сумма citeauthorscopus и citeauthorwos
 \newtotcounter{citeauthorscwostot}
@@ -350,7 +346,6 @@ sorting=none,% настройка сортировки списка литера
 {} %Здесь то, что будет выводиться командой \printbibliography. Обойдёмся без \theciteauthorother в нашей реализации
 {\stepcounter{citeauthorother}} %What is printing / executed at each entry.
 \makeatother
-\defbibheading{countauthorother}{}
 
 \newtotcounter{citeauthorconf}
 \makeatletter
@@ -361,7 +356,6 @@ sorting=none,% настройка сортировки списка литера
 {} %Здесь то, что будет выводиться командой \printbibliography. Обойдёмся без \theciteauthorconf в нашей реализации
 {\stepcounter{citeauthorconf}} %What is printing / executed at each entry.
 \makeatother
-\defbibheading{countauthorconf}{}
 
 \newtotcounter{citeauthor}
 \makeatletter
@@ -372,8 +366,8 @@ sorting=none,% настройка сортировки списка литера
 {} %Здесь то, что будет выводиться командой \printbibliography. Обойдёмся без \theciteauthor в нашей реализации
 {\stepcounter{citeauthor}} %What is printing / executed at each entry.
 \makeatother
-\defbibheading{countauthor}{}
 
+\defbibheading{nobibheading}{} % пустой заголовок, для подсчёта публикаций с помощью невидимой библиографии
 \defbibheading{authorpublications}[\bibtitleauthor]{\section*{#1}}
 \defbibheading{pubsubgroup}{\noindent\textbf{#1}}
 \defbibheading{externalpublications}{\section*{#1}}

--- a/biblio/biblatex.tex
+++ b/biblio/biblatex.tex
@@ -289,82 +289,52 @@ sorting=none,% настройка сортировки списка литера
 %  {\endlist}
 %  {\item}
 
-%% Счётчик использованных ссылок на литературу, обрабатывающий с учётом неоднократных ссылок
-%http://tex.stackexchange.com/a/66851/79756
-%\newcounter{citenum}
-\newtotcounter{citenum}
+%%% Макросы автоматического подсчёта количества авторских публикаций.
+% Печатают невидимую (пустую) библиографию, считая количество источников.
+% http://tex.stackexchange.com/a/66851/79756
+% 
 \makeatletter
-\defbibenvironment{counter} %Env of bibliography
-  {\setcounter{citenum}{0}%
-  \renewcommand{\blx@driver}[1]{}%
-  } %what is doing at the beginining of bibliography. In your case it's : a. Reset counter b. Say to print nothing when a entry is tested.
-  {} %Здесь то, что будет выводиться командой \printbibliography. \thecitenum сюда писать не надо
-  {\stepcounter{citenum}} %What is printing / executed at each entry.
-\makeatother
-
-
-
-\newtotcounter{citeauthorvak}
-\makeatletter
-\defbibenvironment{countauthorvak} %Env of bibliography
-{\setcounter{citeauthorvak}{0}%
-    \renewcommand{\blx@driver}[1]{}%
-} %what is doing at the beginining of bibliography. In your case it's : a. Reset counter b. Say to print nothing when a entry is tested.
-{} %Здесь то, что будет выводиться командой \printbibliography. Обойдёмся без \theciteauthorvak в нашей реализации
-{\stepcounter{citeauthorvak}} %What is printing / executed at each entry.
-\makeatother
-
-\newtotcounter{citeauthorscopus}
-\makeatletter
-\defbibenvironment{countauthorscopus} %Env of bibliography
-{\setcounter{citeauthorscopus}{0}%
-    \renewcommand{\blx@driver}[1]{}%
-} %what is doing at the beginining of bibliography. In your case it's : a. Reset counter b. Say to print nothing when a entry is tested.
-{} %Здесь то, что будет выводиться командой \printbibliography. Обойдёмся без \theciteauthorscopus в нашей реализации
-{\stepcounter{citeauthorscopus}} %What is printing / executed at each entry.
-\makeatother
-
-\newtotcounter{citeauthorwos}
-\makeatletter
-\defbibenvironment{countauthorwos} %Env of bibliography
-{\setcounter{citeauthorwos}{0}%
-    \renewcommand{\blx@driver}[1]{}%
-} %what is doing at the beginining of bibliography. In your case it's : a. Reset counter b. Say to print nothing when a entry is tested.
-{} %Здесь то, что будет выводиться командой \printbibliography. Обойдёмся без \theciteauthorwos в нашей реализации
-{\stepcounter{citeauthorwos}} %What is printing / executed at each entry.
-\makeatother
-
-% сумма citeauthorscopus и citeauthorwos
-\newtotcounter{citeauthorscwostot}
-
-\newtotcounter{citeauthorother}
-\makeatletter
-\defbibenvironment{countauthorother} %Env of bibliography
-{\setcounter{citeauthorother}{0}%
-    \renewcommand{\blx@driver}[1]{}%
-} %what is doing at the beginining of bibliography. In your case it's : a. Reset counter b. Say to print nothing when a entry is tested.
-{} %Здесь то, что будет выводиться командой \printbibliography. Обойдёмся без \theciteauthorother в нашей реализации
-{\stepcounter{citeauthorother}} %What is printing / executed at each entry.
-\makeatother
-
-\newtotcounter{citeauthorconf}
-\makeatletter
-\defbibenvironment{countauthorconf} %Env of bibliography
-{\setcounter{citeauthorconf}{0}%
-    \renewcommand{\blx@driver}[1]{}%
-} %what is doing at the beginining of bibliography. In your case it's : a. Reset counter b. Say to print nothing when a entry is tested.
-{} %Здесь то, что будет выводиться командой \printbibliography. Обойдёмся без \theciteauthorconf в нашей реализации
-{\stepcounter{citeauthorconf}} %What is printing / executed at each entry.
-\makeatother
-
-\newtotcounter{citeauthor}
-\makeatletter
-\defbibenvironment{countauthor} %Env of bibliography
-{\setcounter{citeauthor}{0}%
-    \renewcommand{\blx@driver}[1]{}%
-} %what is doing at the beginining of bibliography. In your case it's : a. Reset counter b. Say to print nothing when a entry is tested.
-{} %Здесь то, что будет выводиться командой \printbibliography. Обойдёмся без \theciteauthor в нашей реализации
-{\stepcounter{citeauthor}} %What is printing / executed at each entry.
+	\newtotcounter{citenum}
+	\defbibenvironment{counter}
+	    {\setcounter{citenum}{0}\renewcommand{\blx@driver}[1]{}} % begin code: убирает весь выводимый текст
+	    {} % end code
+	    {\stepcounter{citenum}} % item code: cчитает "печатаемые в библиографию" источники
+	
+	\newtotcounter{citeauthorvak}
+	\defbibenvironment{countauthorvak}
+	    {\setcounter{citeauthorvak}{0}\renewcommand{\blx@driver}[1]{}}
+	    {}
+	    {\stepcounter{citeauthorvak}}
+	
+	\newtotcounter{citeauthorscopus}
+	\defbibenvironment{countauthorscopus}
+		{\setcounter{citeauthorscopus}{0}\renewcommand{\blx@driver}[1]{}}
+		{}
+		{\stepcounter{citeauthorscopus}}
+	
+	\newtotcounter{citeauthorwos}
+	\defbibenvironment{countauthorwos}
+		{\setcounter{citeauthorwos}{0}\renewcommand{\blx@driver}[1]{}}
+		{}
+		{\stepcounter{citeauthorwos}}
+	
+	\newtotcounter{citeauthorother}
+	\defbibenvironment{countauthorother}
+		{\setcounter{citeauthorother}{0}\renewcommand{\blx@driver}[1]{}}
+		{}
+		{\stepcounter{citeauthorother}}
+	
+	\newtotcounter{citeauthorconf}
+	\defbibenvironment{countauthorconf}
+		{\setcounter{citeauthorconf}{0}\renewcommand{\blx@driver}[1]{}}
+		{}
+		{\stepcounter{citeauthorconf}}
+	
+	\newtotcounter{citeauthor}
+	\defbibenvironment{countauthor}
+		{\setcounter{citeauthor}{0}\renewcommand{\blx@driver}[1]{}}
+		{}
+		{\stepcounter{citeauthor}}
 \makeatother
 
 \defbibheading{nobibheading}{} % пустой заголовок, для подсчёта публикаций с помощью невидимой библиографии

--- a/common/characteristic.tex
+++ b/common/characteristic.tex
@@ -129,12 +129,6 @@
         \fi
     \end{refsection}%
     \begin{refsection}[bl-authorvak,bl-authorwos,bl-authorscopus,bl-authorother,bl-authorconf]%Блок, позволяющий отобрать из всех работ автора наиболее значимые, и только их вывести в автореферате, но считать в блоке выше общее число работ
-        \printbibliography[heading=countauthorvak, env=countauthorvak, keyword=biblioauthorvak, section=2]%
-        \printbibliography[heading=countauthorwos, env=countauthorwos, keyword=biblioauthorwos, section=2]%
-        \printbibliography[heading=countauthorscopus, env=countauthorscopus, keyword=biblioauthorscopus, section=2]%
-        \printbibliography[heading=countauthorother, env=countauthorother, keyword=biblioauthorother, section=2]%
-        \printbibliography[heading=countauthorconf, env=countauthorconf, keyword=biblioauthorconf, section=2]%
-        \printbibliography[heading=countauthor, env=countauthor, keyword=biblioauthor, section=2]%
         \nocite{vakbib2}%vak
         \nocite{bib1}%other
         \nocite{confbib1}%conf

--- a/common/characteristic.tex
+++ b/common/characteristic.tex
@@ -94,46 +94,83 @@
 
 {\contribution} Автор принимал активное участие \ldots
 
-\ifnumequal{\value{bibliosel}}{0}{% Встроенная реализация с загрузкой файла через движок bibtex8. (При желании, внутри можно использовать обычные ссылки, наподобие `\cite{vakbib1,vakbib2}`).
+\ifnumequal{\value{bibliosel}}{0}
+{%%% Встроенная реализация с загрузкой файла через движок bibtex8. (При желании, внутри можно использовать обычные ссылки, наподобие `\cite{vakbib1,vakbib2}`).
     {\publications} Основные результаты по теме диссертации изложены в XX печатных изданиях,
     X из которых изданы в журналах, рекомендованных ВАК,
     X "--- в тезисах докладов.
-}{% Реализация пакетом biblatex через движок biber
-%Сделана отдельная секция, чтобы не отображались в списке цитированных материалов
-    \begin{refsection}[bl-authorvak,bl-authorwos,bl-authorscopus,bl-authorother,bl-authorconf]% Подсчет и нумерация авторских работ. Засчитываются только те, которые были прописаны внутри \nocite{}.
-        %Чтобы сменить порядок разделов в сгрупированном списке литературы необходимо перетасовать следующие три строчки, а также команды в разделе \newcommand*{\insertbiblioauthorgrouped} в файле biblio/biblatex.tex
-        \printbibliography[heading=nobibheading, env=countauthorvak, keyword=biblioauthorvak, section=1]%
-        \printbibliography[heading=nobibheading,env=countauthorwos, keyword=biblioauthorwos, section=1]%
-        \printbibliography[heading=nobibheading,env=countauthorscopus, keyword=biblioauthorscopus, section=1]%
-        \printbibliography[heading=nobibheading, env=countauthorconf, keyword=biblioauthorconf, section=1]%
-        \printbibliography[heading=nobibheading, env=countauthorother, keyword=biblioauthorother, section=1]%
-        \printbibliography[heading=nobibheading, env=countauthor, keyword=biblioauthor, section=1]%
-        \nocite{%Порядок перечисления в этом блоке определяет порядок вывода в списке публикаций автора
-                vakbib1,vakbib2,%
-                wosbib1,%
-                scbib1,%
-                confbib1,confbib2,%
-                bib1,bib2,%
-        }%
+}% 
+{%%% Реализация пакетом biblatex через движок biber
+    \begin{refsection}[bl-authorvak,bl-authorwos,bl-authorscopus,bl-authorother,bl-authorconf]
+        % Это refsection=1.
+        % Процитированные здесь работы:
+        %  * подсчитываются, для автоматического составления фразы "Основные результаты ..."
+        %  * попадают в авторскую библиографию, при usefootcite==0 и стиле `\insertbiblioauthor` или `\insertbiblioauthorgrouped`
+        %  * нумеруются там в зависимости от порядка команд `\printbibliography` в этом разделе. 
+        %  * при использовании `\insertbiblioauthorgrouped`, порядок команд `\printbibliography` в нём должен быть тем же (см. biblio/biblatex.tex)
+        %
+        % Невидимый библиографический список для подсчёта количества публикаций:
+        \printbibliography[heading=nobibheading, section=1, env=countauthorvak,    keyword=biblioauthorvak]%
+        \printbibliography[heading=nobibheading, section=1, env=countauthorwos,    keyword=biblioauthorwos]%
+        \printbibliography[heading=nobibheading, section=1, env=countauthorscopus, keyword=biblioauthorscopus]%
+        \printbibliography[heading=nobibheading, section=1, env=countauthorconf,   keyword=biblioauthorconf]%
+        \printbibliography[heading=nobibheading, section=1, env=countauthorother,  keyword=biblioauthorother]%
+        \printbibliography[heading=nobibheading, section=1, env=countauthor,       keyword=biblioauthor]%
+        %
+        % Цитирования.
+        %  * Порядок перечисления определяет порядок в библиографии (только внутри подраздела, если `\insertbiblioauthorgrouped`).
+        %  * Если не соблюдать порядок "как для \printbibliography", нумерация в `\insertbiblioauthor` будет кривой.
+        %  * Если цитировать каждый источник отдельной командой --- найти некоторые ошибки будет проще.
+        %
+        %% authorvak
+        \nocite{vakbib1}%
+        \nocite{vakbib2}%
+        %
+        %% authorwos
+        \nocite{wosbib1}%
+        %
+        %% authorscopus
+        \nocite{scbib1}%
+        %
+        %% authorconf
+        \nocite{confbib1}%
+        \nocite{confbib2}%
+        %
+        % authorother
+        \nocite{bib1}%
+        \nocite{bib2}%
+        %
+        %
         {\publications} Основные результаты по теме диссертации изложены в~\arabic{citeauthor}~печатных изданиях,
         \setcounter{citeauthorscwostot}{\value{citeauthorscopus}}%
         \addtocounter{citeauthorscwostot}{\value{citeauthorwos}}%
         \arabic{citeauthorvak} из которых изданы в журналах, рекомендованных ВАК\sloppy%
         \ifnum \value{citeauthorscwostot}>0%
-        , \arabic{citeauthorscwostot} "--- в~периодических научных журналах, индексируемых Web of Science и Scopus\sloppy%
+            , \arabic{citeauthorscwostot} "--- в~периодических научных журналах, индексируемых Web of Science и Scopus\sloppy%
         \fi%
         \ifnum \value{citeauthorconf}>0%
-        , \arabic{citeauthorconf} "--- в~тезисах докладов.
+            , \arabic{citeauthorconf} "--- в~тезисах докладов.
         \else%
-        .
+            .
         \fi
     \end{refsection}%
-    \begin{refsection}[bl-authorvak,bl-authorwos,bl-authorscopus,bl-authorother,bl-authorconf]%Блок, позволяющий отобрать из всех работ автора наиболее значимые, и только их вывести в автореферате, но считать в блоке выше общее число работ
+    \begin{refsection}[bl-authorvak,bl-authorwos,bl-authorscopus,bl-authorother,bl-authorconf]
+        % Это refsection=2.
+        % Процитированные здесь работы:
+        %  * попадают в авторскую библиографию, при usefootcite==0 и стиле `\insertbiblioauthorimportant`.
+        %  * ни на что не влияют в противном случае
         \nocite{vakbib2}%vak
         \nocite{bib1}%other
         \nocite{confbib1}%conf
     \end{refsection}%
-}%
+	%
+	% Всё, что вне этих двух refsection, это refsection=0,
+	%  * для диссертации - это нормальные ссылки, попадающие в обычную библиографию
+	%  * для автореферата:
+	%     * при usefootcite==0, ссылка корректно сработает только для источника из `external.bib`. Для своих работ --- напечатает "[0]" (и даже Warning не вылезет).
+	%     * при usefootcite==1, ссылка сработает нормально. В авторской библиографии будут только процитированные в refsection=0 работы.
+}
+
 При использовании пакета \verb!biblatex! для автоматического подсчёта
 количества публикаций автора по теме диссертации, необходимо
-их~здесь перечислить с использованием команды \verb!\nocite!.
+их~перечислить с использованием команды \verb!\nocite! в \verb!common/characteristic.tex!

--- a/common/characteristic.tex
+++ b/common/characteristic.tex
@@ -102,12 +102,12 @@
 %Сделана отдельная секция, чтобы не отображались в списке цитированных материалов
     \begin{refsection}[bl-authorvak,bl-authorwos,bl-authorscopus,bl-authorother,bl-authorconf]% Подсчет и нумерация авторских работ. Засчитываются только те, которые были прописаны внутри \nocite{}.
         %Чтобы сменить порядок разделов в сгрупированном списке литературы необходимо перетасовать следующие три строчки, а также команды в разделе \newcommand*{\insertbiblioauthorgrouped} в файле biblio/biblatex.tex
-        \printbibliography[heading=countauthorvak, env=countauthorvak, keyword=biblioauthorvak, section=1]%
-        \printbibliography[heading=countauthorwos,env=countauthorwos, keyword=biblioauthorwos, section=1]%
-        \printbibliography[heading=countauthorscopus,env=countauthorscopus, keyword=biblioauthorscopus, section=1]%
-        \printbibliography[heading=countauthorconf, env=countauthorconf, keyword=biblioauthorconf, section=1]%
-        \printbibliography[heading=countauthorother, env=countauthorother, keyword=biblioauthorother, section=1]%
-        \printbibliography[heading=countauthor, env=countauthor, keyword=biblioauthor, section=1]%
+        \printbibliography[heading=nobibheading, env=countauthorvak, keyword=biblioauthorvak, section=1]%
+        \printbibliography[heading=nobibheading,env=countauthorwos, keyword=biblioauthorwos, section=1]%
+        \printbibliography[heading=nobibheading,env=countauthorscopus, keyword=biblioauthorscopus, section=1]%
+        \printbibliography[heading=nobibheading, env=countauthorconf, keyword=biblioauthorconf, section=1]%
+        \printbibliography[heading=nobibheading, env=countauthorother, keyword=biblioauthorother, section=1]%
+        \printbibliography[heading=nobibheading, env=countauthor, keyword=biblioauthor, section=1]%
         \nocite{%Порядок перечисления в этом блоке определяет порядок вывода в списке публикаций автора
                 vakbib1,vakbib2,%
                 wosbib1,%

--- a/common/characteristic.tex
+++ b/common/characteristic.tex
@@ -142,6 +142,7 @@
         %
         %
         {\publications} Основные результаты по теме диссертации изложены в~\arabic{citeauthor}~печатных изданиях,
+        \newcounter{citeauthorscwostot}% сумма citeauthorscopus и citeauthorwos
         \setcounter{citeauthorscwostot}{\value{citeauthorscopus}}%
         \addtocounter{citeauthorscwostot}{\value{citeauthorwos}}%
         \arabic{citeauthorvak} из которых изданы в журналах, рекомендованных ВАК\sloppy%


### PR DESCRIPTION
1. Убраны ни на что не влияющие `\printbibliography` из refsection 2. Они там, вроде бы, всяко не нужны - там ни выводить, ни просто подсчитывать источники не нужно. Они только Warning'и ненужные кидают, даже когда `\insertbiblioauthorimportant` не используется.
2. Единый пустой `nobibheading` - создавать несколько одинаковых пустых смысла нет, я так понимаю.
3. Немного почищен код в `biblatex.tex`.