### PR TITLE
Замена последнего забытого пустого bibheading "counter" на nonbibheading

### DIFF
--- a/biblio/biblatex.tex
+++ b/biblio/biblatex.tex
@@ -346,7 +346,7 @@ sorting=none,% настройка сортировки списка литера
 %%% Создание команд для вывода списка литературы %%%
 \newcommand*{\insertbibliofull}{
 \printbibliography[keyword=bibliofull,section=0,title=\fullbibtitle]
-\printbibliography[heading=counter,env=counter,keyword=bibliofull,section=0]
+\printbibliography[heading=nobibheading,env=counter,keyword=bibliofull,section=0]
 }
 
 \newcommand*{\insertbiblioauthorcited}{


### PR DESCRIPTION
Проворонил я в 04bbf56 `\printbibliography[heading=counter`. Что [сломало](https://github.com/AndreyAkinshin/Russian-Phd-LaTeX-Dissertation-Template/pull/312#issuecomment-489417392) диссертацию.
Здесь и этот заголовок библиографии заменется на единый `nonbibheading`.