### PR TITLE
Рефакторинг макросов библиографии

### DIFF
--- a/biblio/biblatex.tex
+++ b/biblio/biblatex.tex
@@ -338,9 +338,8 @@ sorting=none,% настройка сортировки списка литера
 \makeatother
 
 \defbibheading{nobibheading}{} % пустой заголовок, для подсчёта публикаций с помощью невидимой библиографии
-\defbibheading{authorpublications}[\bibtitleauthor]{\section*{#1}}
-\defbibheading{pubsubgroup}{\noindent\textbf{#1}}
-\defbibheading{externalpublications}{\section*{#1}}
+\defbibheading{pubgroup}[\bibtitleauthor]{\section*{#1}} % обычный стиль, заголовок-секция
+\defbibheading{pubsubgroup}{\noindent\textbf{#1}} % для подразделов "по типу источника"
 
 
 %%% Создание команд для вывода списка литературы %%%
@@ -350,13 +349,15 @@ sorting=none,% настройка сортировки списка литера
 }
 
 \newcommand*{\insertbiblioauthorcited}{
-\printbibliography[heading=authorpublications,keyword=biblioauthor,section=0,title=\bibtitleauthor]
+\printbibliography[heading=pubgroup,keyword=biblioauthor,section=0,title=\bibtitleauthor]
 }
 \newcommand*{\insertbiblioauthor}{
-\printbibliography[heading=authorpublications,keyword=biblioauthor,section=1,title=\bibtitleauthor]
+\printbibliography[heading=pubgroup,keyword=biblioauthor,section=1,title=\bibtitleauthor]
 }
+
+% Вариант вывода печатных работ автора, с перечислением только указанных в refsection=2
 \newcommand*{\insertbiblioauthorimportant}{
-\printbibliography[heading=authorpublications,keyword=biblioauthor,section=2,title={Наиболее значимые \MakeLowercase{\protect\bibtitleauthor{}}}]
+\printbibliography[heading=pubgroup,keyword=biblioauthor,section=2,title={Наиболее значимые \MakeLowercase{\protect\bibtitleauthor{}}}]
 }
 \newcommand*{\insertbiblioauthorgrouped}{% Заготовка для вывода сгруппированных печатных работ автора. Порядок нумерации определяется в соответствующих счетчиках внутри окружения refsection в файле common/characteristic.tex
 \section*{\bibtitleauthor}
@@ -368,5 +369,5 @@ sorting=none,% настройка сортировки списка литера
 }
 
 \newcommand*{\insertbiblioexternal}{
-\printbibliography[heading=externalpublications,keyword=biblioexternal]
+    \printbibliography[heading=pubgroup,keyword=biblioexternal]
 }

--- a/biblio/biblatex.tex
+++ b/biblio/biblatex.tex
@@ -353,9 +353,8 @@ sorting=none,% настройка сортировки списка литера
 \newcommand*{\insertbiblioauthor}{
     \printbibliography[heading=pubgroup, section=1, keyword=biblioauthor, title=\bibtitleauthor]
 }
-
 \newcommand*{\insertbiblioauthorimportant}{
-    \printbibliography[heading=pubgroup, section=2, keyword=biblioauthor,  title={Наиболее значимые \MakeLowercase{\protect\bibtitleauthor{}}}]
+    \printbibliography[heading=pubgroup, section=2, keyword=biblioauthor, title=\bibtitleauthorimportant]
 }
 
 % Вариант вывода печатных работ автора, с группировкой по типу источника. 

--- a/biblio/biblatex.tex
+++ b/biblio/biblatex.tex
@@ -344,28 +344,29 @@ sorting=none,% настройка сортировки списка литера
 
 %%% Создание команд для вывода списка литературы %%%
 \newcommand*{\insertbibliofull}{
-\printbibliography[keyword=bibliofull,section=0,title=\fullbibtitle]
-\printbibliography[heading=nobibheading,env=counter,keyword=bibliofull,section=0]
+    \printbibliography[keyword=bibliofull,section=0,title=\fullbibtitle]
+    \printbibliography[heading=nobibheading,env=counter,keyword=bibliofull,section=0]
 }
-
 \newcommand*{\insertbiblioauthorcited}{
-\printbibliography[heading=pubgroup,keyword=biblioauthor,section=0,title=\bibtitleauthor]
+    \printbibliography[heading=pubgroup, section=0, keyword=biblioauthor, title=\bibtitleauthor]
 }
 \newcommand*{\insertbiblioauthor}{
-\printbibliography[heading=pubgroup,keyword=biblioauthor,section=1,title=\bibtitleauthor]
+    \printbibliography[heading=pubgroup, section=1, keyword=biblioauthor, title=\bibtitleauthor]
 }
 
-% Вариант вывода печатных работ автора, с перечислением только указанных в refsection=2
 \newcommand*{\insertbiblioauthorimportant}{
-\printbibliography[heading=pubgroup,keyword=biblioauthor,section=2,title={Наиболее значимые \MakeLowercase{\protect\bibtitleauthor{}}}]
+    \printbibliography[heading=pubgroup, section=2, keyword=biblioauthor,  title={Наиболее значимые \MakeLowercase{\protect\bibtitleauthor{}}}]
 }
-\newcommand*{\insertbiblioauthorgrouped}{% Заготовка для вывода сгруппированных печатных работ автора. Порядок нумерации определяется в соответствующих счетчиках внутри окружения refsection в файле common/characteristic.tex
-\section*{\bibtitleauthor}
-\printbibliography[heading=pubsubgroup, keyword=biblioauthorvak, section=1, title=\bibtitleauthorvak]%
-\printbibliography[heading=pubsubgroup, keyword=biblioauthorwos, section=1, title=\bibtitleauthorwos]%
-\printbibliography[heading=pubsubgroup, keyword=biblioauthorscopus, section=1, title=\bibtitleauthorscopus]%
-\printbibliography[heading=pubsubgroup, keyword=biblioauthorconf, section=1, title=\bibtitleauthorconf]%
-\printbibliography[heading=pubsubgroup, keyword=biblioauthorother, section=1, title=\bibtitleauthorother]%
+
+% Вариант вывода печатных работ автора, с группировкой по типу источника. 
+% Порядок команд `\printbibliography` должен соответствовать порядку в файле common/characteristic.tex
+\newcommand*{\insertbiblioauthorgrouped}{
+    \section*{\bibtitleauthor}
+    \printbibliography[heading=pubsubgroup, section=1, keyword=biblioauthorvak,    title=\bibtitleauthorvak]%
+    \printbibliography[heading=pubsubgroup, section=1, keyword=biblioauthorwos,    title=\bibtitleauthorwos]%
+    \printbibliography[heading=pubsubgroup, section=1, keyword=biblioauthorscopus, title=\bibtitleauthorscopus]%
+    \printbibliography[heading=pubsubgroup, section=1, keyword=biblioauthorconf,   title=\bibtitleauthorconf]%
+    \printbibliography[heading=pubsubgroup, section=1, keyword=biblioauthorother,  title=\bibtitleauthorother]%
 }
 
 \newcommand*{\insertbiblioexternal}{

--- a/biblio/biblatex.tex
+++ b/biblio/biblatex.tex
@@ -344,7 +344,7 @@ sorting=none,% настройка сортировки списка литера
 
 %%% Создание команд для вывода списка литературы %%%
 \newcommand*{\insertbibliofull}{
-    \printbibliography[keyword=bibliofull,section=0,title=\fullbibtitle]
+    \printbibliography[keyword=bibliofull,section=0,title=\bibtitlefull]
     \printbibliography[heading=nobibheading,env=counter,keyword=bibliofull,section=0]
 }
 \newcommand*{\insertbiblioauthorcited}{

--- a/common/newnames.tex
+++ b/common/newnames.tex
@@ -34,4 +34,4 @@
 \newcommand{\bibtitleauthorwos}{В изданиях, входящих в международную базу цитирования Web of Science}
 \newcommand{\bibtitleauthorother}{В прочих изданиях}
 \newcommand{\bibtitleauthorconf}{В сборниках трудов конференций}
-\newcommand{\fullbibtitle}{Список литературы} % (ГОСТ Р 7.0.11-2011, 4)
+\newcommand{\bibtitlefull}{Список литературы} % (ГОСТ Р 7.0.11-2011, 4)

--- a/common/newnames.tex
+++ b/common/newnames.tex
@@ -34,4 +34,5 @@
 \newcommand{\bibtitleauthorwos}{В изданиях, входящих в международную базу цитирования Web of Science}
 \newcommand{\bibtitleauthorother}{В прочих изданиях}
 \newcommand{\bibtitleauthorconf}{В сборниках трудов конференций}
+\newcommand{\bibtitleauthorimportant}{Наиболее значимые \protect\MakeLowercase\bibtitleauthor}
 \newcommand{\bibtitlefull}{Список литературы} % (ГОСТ Р 7.0.11-2011, 4)

--- a/common/newnames.tex
+++ b/common/newnames.tex
@@ -28,11 +28,20 @@
 \newcommand{\publicationsTXT}{Публикации.}
 
 
+%%% Заголовки библиографии:
+
+% для автореферата:
 \newcommand{\bibtitleauthor}{Публикации автора по теме диссертации}
+
+% для стиля библиографии `\insertbiblioauthorgrouped`
 \newcommand{\bibtitleauthorvak}{В изданиях из списка ВАК РФ}
 \newcommand{\bibtitleauthorscopus}{В изданиях, входящих в международную базу цитирования Scopus}
 \newcommand{\bibtitleauthorwos}{В изданиях, входящих в международную базу цитирования Web of Science}
 \newcommand{\bibtitleauthorother}{В прочих изданиях}
 \newcommand{\bibtitleauthorconf}{В сборниках трудов конференций}
+
+% для стиля библиографии `\insertbiblioauthorimportant`:
 \newcommand{\bibtitleauthorimportant}{Наиболее значимые \protect\MakeLowercase\bibtitleauthor}
+
+% для диссертации:
 \newcommand{\bibtitlefull}{Список литературы} % (ГОСТ Р 7.0.11-2011, 4)

--- a/common/renames.tex
+++ b/common/renames.tex
@@ -4,4 +4,4 @@
 \renewcommand{\tablename}{Таблица} % (ГОСТ Р 7.0.11-2011, 5.3.10)
 \renewcommand{\listfigurename}{Список рисунков}
 \renewcommand{\listtablename}{Список таблиц}
-\renewcommand{\bibname}{\fullbibtitle}
+\renewcommand{\bibname}{\bibtitlefull}


### PR DESCRIPTION
* Конструкция `\MakeLowercase{\protect\bibtitleauthor{}}` не срабатывала - буквы не становились маленькими. И оно было единственной строкой захардкоденной в `biblatex.tex ` строкой.
* прочий мелкий рефакторинг
