### PR TITLE
Исправление бага с неправильным заголовком \insertbiblioexternal

### DIFF
--- a/Synopsis/content.tex
+++ b/Synopsis/content.tex
@@ -69,7 +69,7 @@
 
 При использовании пакета \verb!biblatex! список публикаций автора по теме
 диссертации формируется в разделе <<\publications>>\ файла
-\verb!../common/characteristic.tex!  при помощи команды \verb!\nocite!
+\verb!common/characteristic.tex!  при помощи команды \verb!\nocite!
 
 \ifdefmacro{\microtypesetup}{\microtypesetup{protrusion=false}}{} % не рекомендуется применять пакет микротипографики к автоматически генерируемому списку литературы
 \ifnumequal{\value{bibliosel}}{0}{% Встроенная реализация с загрузкой файла через движок bibtex8

--- a/biblio/biblatex.tex
+++ b/biblio/biblatex.tex
@@ -338,7 +338,7 @@ sorting=none,% настройка сортировки списка литера
 \makeatother
 
 \defbibheading{nobibheading}{} % пустой заголовок, для подсчёта публикаций с помощью невидимой библиографии
-\defbibheading{pubgroup}[\bibtitleauthor]{\section*{#1}} % обычный стиль, заголовок-секция
+\defbibheading{pubgroup}{\section*{#1}} % обычный стиль, заголовок-секция
 \defbibheading{pubsubgroup}{\noindent\textbf{#1}} % для подразделов "по типу источника"
 
 
@@ -369,5 +369,5 @@ sorting=none,% настройка сортировки списка литера
 }
 
 \newcommand*{\insertbiblioexternal}{
-    \printbibliography[heading=pubgroup,keyword=biblioexternal]
+    \printbibliography[heading=pubgroup,    section=0, keyword=biblioexternal,     title=\bibtitlefull]
 }

--- a/common/characteristic.tex
+++ b/common/characteristic.tex
@@ -136,7 +136,7 @@
         \nocite{confbib1}%
         \nocite{confbib2}%
         %
-        % authorother
+        %% authorother
         \nocite{bib1}%
         \nocite{bib2}%
         %

--- a/common/newnames.tex
+++ b/common/newnames.tex
@@ -43,5 +43,5 @@
 % для стиля библиографии `\insertbiblioauthorimportant`:
 \newcommand{\bibtitleauthorimportant}{Наиболее значимые \protect\MakeLowercase\bibtitleauthor}
 
-% для диссертации:
+% для списка литературы в диссертации и списка чужих работ в автореферате:
 \newcommand{\bibtitlefull}{Список литературы} % (ГОСТ Р 7.0.11-2011, 4)


### PR DESCRIPTION
1.  Исправление бага с неправильным заголовком библиографии, посаженного в c1aa9aab7f9649c747275caaf25f7cdf2b325533 .
2. Пара мелких косметических правок, для получения более однородного стиля