### PR TITLE
beamer xelatex workaround fix

### DIFF
--- a/Presentation/prespreamble.tex
+++ b/Presentation/prespreamble.tex
@@ -12,17 +12,16 @@
 	\ifnumequal{\value{presnotes}}{2}{
 		\setbeameroption{show notes on second screen=\presposition}
 	}{}
-	% https://tex.stackexchange.com/a/291545/104425
-	\usepackage[normalem]{ulem}
-	\makeatletter
-	\def\beamer@framenotesbegin{% at beginning of slide
-		\usebeamercolor[fg]{normal text}
-		\gdef\beamer@noteitems{}%
-		\gdef\beamer@notes{}%
-	}
-	\makeatother
 }
 
+% https://tex.stackexchange.com/a/291545/104425
+\makeatletter
+\def\beamer@framenotesbegin{% at beginning of slide
+	\usebeamercolor[fg]{normal text}
+	\gdef\beamer@noteitems{}%
+	\gdef\beamer@notes{}%
+}
+\makeatother
 
 % \usetheme[secheader]{Boadilla}
 % \usecolortheme{seahorse}


### PR DESCRIPTION
Предложенное в [tex.so](https://tex.stackexchange.com/a/306662/104425) решение проблемы с исчезновением текста в презентации (#299) заработало после вынесения его за блок `\ifnumequal`
 