### PR TITLE
Оформление первого слайда презентации через \setbeamertemplate

### DIFF
--- a/Presentation/prescontent.tex
+++ b/Presentation/prescontent.tex
@@ -178,7 +178,7 @@ $$
 \end{itemize}
 \end{frame}
 
-\begin{frame}
+\begin{frame}[plain] % последний слайд без оформления
 \begin{center}
 Спасибо за внимание!
 \end{center}

--- a/Presentation/prespreamble.tex
+++ b/Presentation/prespreamble.tex
@@ -54,16 +54,55 @@
 
 \newcommand{\itemi}{\item[\checkmark]}
 
+\setbeamertemplate{title page}
+{
+	\ifnumequal{\value{logotitle}}{1}{
+		\IfFileExists{images/logo.pdf}{
+			% изменить размер логотипа можно, изменяя размер minipage
+			% при этом не забыть соответственно изменить размер следующей minipage
+			\begin{minipage}[c]{0.15\textwidth}
+				\begin{flushleft}
+					\usebeamercolor[fg]{titlegraphic}\inserttitlegraphic
+				\end{flushleft}
+			\end{minipage}%
+			\hfill
+			\begin{minipage}[b]{0.8\linewidth}
+				\centering
+				\usebeamerfont{institute}\insertinstitute\par
+			\end{minipage}
+		}{
+			\centering
+			\usebeamerfont{institute}\insertinstitute\par
+		}
+	}{
+		\centering
+		\usebeamerfont{institute}\insertinstitute\par
+	}
+	\centering
+	\vfill
+	\usebeamerfont{title}\small\inserttitle\par
+	\usebeamerfont{subtitle}\insertsubtitle\par
+	\vfill
+	\usebeamerfont{author}\small\insertauthor\par
+	\vfill
+	\usebeamerfont{date}\small\insertdate\par
+}
+
 %\title{\small{Название презентации}}
-\title{\small{\thesisTitle}}
+\title{\thesisTitle}
 \author{%
     \texorpdfstring{%
-        \small{%
         \emph{Выступающий:}~\thesisAuthorShort\\%
-        \emph{Руководитель:}~\supervisorRegaliaShort~\supervisorFioShort}\\%
-        \vspace{10pt}%
-        \thesisOrganization%
-        \vfill%
+        \emph{Руководитель:}~\supervisorRegaliaShort~\supervisorFioShort\\%
+        %
     }{\thesisAuthor}%
 }
-\date{\texorpdfstring{\small{\thesisCity, \thesisYear}}{}}
+\date{\texorpdfstring{\thesisCity, \thesisYear}{}}
+\institute{\texorpdfstring{\thesisOrganization}{}}
+\IfFileExists{images/logo.pdf}{
+	\titlegraphic{\includegraphics[width=\textwidth]{images/logo}}
+	\ifnumequal{\value{logoother}}{1}{
+		% размер логотипа для каждой странице задаётся здесь
+		\logo{\includegraphics[width=0.15\textwidth]{images/logo}}
+	}{}
+}{}

--- a/Presentation/setup.tex
+++ b/Presentation/setup.tex
@@ -1,12 +1,30 @@
 %%% Добавление поясняющих записей (notes) к презентации %%%
 \makeatletter
 \@ifundefined{c@presnotes}{
-	\newcounter{presnotes}
-	\setcounter{presnotes}{0}       % 0 --- выкл;
-					% 1 --- вкл, записи на отдельном слайде;
-					% 2 --- вкл, записи на основном слайде;
+        \newcounter{presnotes}
+        \setcounter{presnotes}{0}      % 0 --- выкл;
+                                       % 1 --- вкл, записи на отдельном слайде;
+                                       % 2 --- вкл, записи на основном слайде;
 }{}
 \makeatother
 
 %%% Положение поясняющих записей (notes) при значении presnotes=2 %%%
 \newcommand{\presposition}{left}  % возможные значения: left, right, top, bottom
+
+%%% Добавление логотипа из файла images/logo на первом слайде %%%
+\makeatletter
+\@ifundefined{c@logotitle}{
+        \newcounter{logotitle}
+        \setcounter{logotitle}{1}      % 0 --- выкл;
+                                       % 1 --- вкл
+}{}
+\makeatother
+
+%%% Добавление логотипа из файла images/logo на слайдах (кроме первого и последнего) %%%
+\makeatletter
+\@ifundefined{c@logoother}{
+        \newcounter{logoother}
+        \setcounter{logoother}{0}      % 0 --- выкл;
+                                       % 1 --- вкл
+}{}
+\makeatother


### PR DESCRIPTION
Изменён первый слайд презентации. Добавлен логотип. Пользователь при желании теперь может изменять положение элементов  на первом слайде в файле `Presentation/prespreamble.tex`.
![1](https://user-images.githubusercontent.com/26824900/59513819-4b535f00-8ec4-11e9-81f6-59eacacc189b.png)

На остальные слайды тоже добавлен логотип.
![2](https://user-images.githubusercontent.com/26824900/59514039-c0bf2f80-8ec4-11e9-9d4f-1237e68caa7d.png)

Вывод логотипов контролируется двумя переменными в файле `Presentation/setup.tex`.


