### PR TITLE
ignore .pdf .ps .eps in root folder only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,9 +16,9 @@
 *.xdv
 *-converted-to.*
 # these rules might exclude image files for figures etc.
-*.ps
-*.eps
-*.pdf
+/*.ps
+/*.eps
+/*.pdf
 
 ## Bibliography auxiliary files (bibtex/biblatex/biber):
 *.bbl


### PR DESCRIPTION
Данное изменение позволяет игнорировать файлы с расширением `.pdf`,  `.ps` и  `.eps` только в корневом каталоге. git будет следить за изменениями файлов с этими расширениями в остальных директориях. Например, в `images`.