### PR TITLE
добавлена возможность использования пробелов в \labelcref

### DIFF
--- a/Dissertation/part1.tex
+++ b/Dissertation/part1.tex
@@ -241,5 +241,5 @@ test:eisner-sample-shorted, AB_patent_Pomerantz_1968, iofis_patent1960}
 
 Используя команду \verb|\labelcref| из пакета \verb|cleveref|, можно
 красиво ссылаться сразу на несколько формул
-(\labelcref{eq:equation1,eq:equation3,eq:equation2}), даже перепутав
-порядок ссылок \verb|(\labelcref{eq:equation1,eq:equation3,eq:equation2})|.
+(\labelcref{eq:equation1, eq:equation3, eq:equation2}), даже перепутав
+порядок ссылок \verb|(\labelcref{eq:equation1, eq:equation3, eq:equation2})|.

--- a/common/packages.tex
+++ b/common/packages.tex
@@ -118,6 +118,18 @@
     \fi
     \creflabelformat{equation}{#2#1#3}                  % Формат по умолчанию ставил круглые скобки вокруг каждого номера ссылки, теперь просто номера ссылок без какого-либо дополнительного оформления
     \crefrangelabelformat{equation}{#3#1#4\cyrdash#5#2#6}   % Интервалы в русском языке принято делать через тире, если иное не оговорено
+
+    % Добавление возможности использования пробелов в \labelcref
+    % https://tex.stackexchange.com/a/340502/104425
+    \usepackage{kvsetkeys}
+    \makeatletter
+    \let\org@@cref\@cref
+    \renewcommand*{\@cref}[2]{%
+        \edef\process@me{%
+            \noexpand\org@@cref{#1}{\zap@space#2 \@empty}%
+        }\process@me
+    }
+    \makeatother
 \fi
 
 \ifnumequal{\value{draft}}{1}{% Черновик


### PR DESCRIPTION
При использовании latexindent с включённым [text wrap](http://mirror.macomnet.net/pub/CTAN/support/latexindent/documentation/latexindent.pdf#subsection.6.1) разбиваются ссылки в команде `\labelcref` из-за отсутствия пробелов между ссылками.
Проблема решается добавлением возможности использования пробелов в `\labelcref`.
Решение взято [отсюда](https://tex.stackexchange.com/a/340502/104425).