### PR TITLE
добавлен рецепт для разбиения длинных строк в исходных файлах

### DIFF
--- a/indent.yaml
+++ b/indent.yaml
@@ -20,3 +20,7 @@ specialBeginEnd:
 
 indentRulesGlobal:
     UnNamedGroupingBracesBrackets: 1
+
+modifyLineBreaks:
+    textWrapOptions:
+        columns: 80

--- a/unix.mk
+++ b/unix.mk
@@ -18,6 +18,10 @@ indent:
 	@$(foreach file, $(INDENT_FILES),\
 	latexindent -l=$(INDENT_SETTINGS) -s -w $(file);)
 
+##! форматирование файлов *.tex с разбиением длинных строк
+indent-wrap: INDENT_SETTINGS+=-m
+indent-wrap: indent
+
 ##! предкомпиляция диссертации и автореферата
 preformat: synopsis-preformat dissertation-preformat \
 presentation-preformat
@@ -80,5 +84,5 @@ help:
 	}' \
 	| more $(shell test $(shell uname) = Darwin && echo '--no-init --raw-control-chars')
 
-.PHONY: indent preformat dissertation-preformat \
+.PHONY: indent indent-wrap preformat dissertation-preformat \
 synopsis-preformat presentation-preformat help

--- a/windows.mk
+++ b/windows.mk
@@ -19,4 +19,8 @@ indent:
 	latexindent -l=$(INDENT_SETTINGS) -s -w $(file) &&)\
 	echo "done"
 
-.PHONY: indent
+##! форматирование файлов *.tex с разбиением длинных строк
+indent-wrap: INDENT_SETTINGS+=-m
+indent-wrap: indent
+
+.PHONY: indent indent-wrap


### PR DESCRIPTION
Добавлен рецепт для разбиения длинных строк в исходных файлах при помощи `latexindent`.
Максимальная длина строки составляет 80 символов.