### PR TITLE
added dockertex - fix for #305

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM raabf/texstudio-versions:texlive2018
+RUN echo 'deb http://deb.debian.org/debian/ buster  contrib non-free' >> /etc/apt/sources.list
+RUN echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections 
+RUN apt-get update -q && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -qy fonts-liberation ttf-mscorefonts-installer
+RUN fc-cache -f -v

--- a/Readme/Installation.md
+++ b/Readme/Installation.md
@@ -2,8 +2,9 @@
 
 * [Быстрый старт](#Быстрый-старт)
 * Установка
+  * [В Ubuntu с TexLive внутри контейнера DockerTex](#В-ubuntu-с-texlive-внутри-контейнера-dockertex)
   * [В Ubuntu](#В-ubuntu)
-  * [В Debian9](#В-debian)
+  * [В Debian](#В-debian)
   * [В Fedora](#В-fedora)
   * [В Gentoo](#В-gentoo)
   * [TeXLive на Linux в обход привязанных к конкретному линуксу пакетам](#texlive-на-linux-в-обход-привязанных-к-конкретному-линуксу-пакетам)
@@ -74,15 +75,57 @@
 
 ## Установка
 
+### В Ubuntu с TexLive внутри контейнера DockerTex
+
+> Протестировано в Ubuntu 16.04 LTS и Ubuntu 18.04 LTS
+
+Для обеспечения максимальной воспроизводимости сборки проекта рекомендуется использовать специализиарованный Docker-контейнер от проекта [dockertex](https://gitlab.com/raabf/dockertex), базирующийся на Debian Buster 10 и TexLive 2018, с минимальной модификацией (добавлением пакета шрифтов от Microsoft - `ttf-mscorefonts-installer` и набора шрифтов Liberation в виде пакета `fonts-liberation`). Образ контейнера объемом около 2.5 Гб будет загружен из сети, при этом с учетом этапа распаковки в системе потребуется около 8 Гб свободного места в каталоге `/var`.
+
+Установка контейнера в вашу систему выполняется путем запуска соответствующего скрипта, находящегося в корне этого шаблона:
+
+```bash
+sh install-dockertex.sh
+```
+
+Далее необходимо выйти из системы и зайти снова (либо перезагрузиться).
+
+После этого станут доступны две новых команды - `dockertex` и `dockertexstudio`.
+Для TexStudio будет создан ярлык с названием *Docker TexStudio (texlive2018)* в категории *Office*.
+
+**Команда `dockertex`** используется для сборки проекта - диссертации, автореферата и презентации (по сути это `make` без аргументов):
+
+```bash
+dockertex make
+```
+
+После выполнения команды будут созданы три PDF-файла: `dissertation.pdf`, `presentation.pdf` и `synopsis.pdf`.
+
+При необходимости можно запустить `make clean`:
+
+```bash
+dockertex make clean
+```
+
+Остальные аргументы `make` могут быть вызваны аналогично.
+
+**Команда `dockertexstudio`** используется для запуска TexStudio из контейнера:
+
+```bash
+dockertexstudio
+```
+
+После открытия файла `dissertation.tex` и нажатия <F5> будет создан PDF диссертации.
+
 ### В Ubuntu
 
-> Протестировано на Ubuntu 15.04.
+> Протестировано на Ubuntu 19.04.
+> Для LTS-версий рекомендуется использование [DockerTex](#В-ubuntu-с-texlive-внутри-контейнера-dockertex)
 
 Для установки XeTeX в Ubuntu и необходимых дополнительных пакетов можно
 использовать команду:
 
 ```bash
-sudo apt-get install texlive-xetex texlive-generic-extra texlive-lang-cyrillic latexmk biber
+sudo apt-get install make texlive-xetex texlive-generic-extra texlive-lang-cyrillic texlive-lang-french fonts-liberation latexmk biber
 ```
 
 или для установки полного комплекта программ:
@@ -90,7 +133,6 @@ sudo apt-get install texlive-xetex texlive-generic-extra texlive-lang-cyrillic l
 ```bash
 sudo apt-get install texlive-full
 ```
-
 
 Для использования шрифтов Microsoft требуется их установка.
 Например, для Ubuntu это можно сделать так:
@@ -102,22 +144,11 @@ sudo fc-cache -fv
 
 ### В Debian
 
-> Протестировано на Debian 9.
+> Протестировано на Debian 10.
 
-Установка аналогична Ubuntu. При этом может не хватать некоторых стилевых
-пакетов для тестовой сборки образцовой диссертационной работы из этого шаблона.
-Например, при компиляции может появиться сообщение вида:
-```bash
-File `impnattypo.sty' not found. ^^M
-```
-Для преодоления такого препятствия в менеджере пакетов который вам больше
-нравится ищите `impnattypo`.
-В результатах поиска будет пакет содержащий данный стиль, этот пакет нужно
-поставить стандартным способом. После этого сообщения:
-```bash
-File `impnattypo.sty' not found. ^^M
-```
-не будет и компиляция пойдет нормально.
+Установка аналогична Ubuntu.
+
+Для установки шрифтов Microsoft должен быть подключен репозиторий `contrib`.
 
 ### В Fedora
 

--- a/install-dockertex.sh
+++ b/install-dockertex.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+# 1. Установка Docker и Git
+echo "==> Installing Docker and Git packages"
+sudo add-apt-repository universe 
+sudo apt-get update
+sudo apt-get install -qy docker.io git
+sudo usermod -a -G docker $USER
+
+# 2. Установка DockerTex
+echo "==> Downloading and updating docker image"
+sg docker -c "docker build -t raabf/texstudio-versions:texlive2018 ."
+
+# 3. Настройка DockerTex
+## 3.1 Клонирование репозитория
+echo "==> Downloading dockertex"
+DOWNLOADS_DIR=$(xdg-user-dir DOWNLOAD)
+cd $DOWNLOADS_DIR && git clone https://github.com/raabf/dockertex.git
+
+echo "==> Registering dockertex commands and shortcuts"
+## 3.2 Регистрация в системе - добавление команд dockertex и dockertexstudio
+sudo $DOWNLOADS_DIR/dockertex/install.sh --system --menu-volume DockerTexLive2018 --menu-tag texlive2018
+
+echo "==> Fixing start of TexStudio"
+## 3.3 Исправление для запуска TexStudio
+sudo sed -i '/--net=host\ \\/d' /usr/local/bin/dockertexstudio
+
+## 3.4 Добавление переменной окружения с указанием версии DockerTex
+echo "==> Adding DockerTex tag to environment variables"
+echo "export DOCKERTEX_DEFAULT_TAG=texlive2018" >> ~/.profile
+echo "export DOCKERTEX_DEFAULT_TAG=texlive2018" >> ~/.bashrc
+


### PR DESCRIPTION
Этот коммит результат обсуждения проблемы #305. 

В итоге я пришел к следующему решению - используем образ Docker-контейнера от проекта `dockertex` (как я уже писал [в комментарии](https://github.com/AndreyAkinshin/Russian-Phd-LaTeX-Dissertation-Template/issues/305#issuecomment-515779775)) с минимальной модификацией - добавлением пакета шрифтов от Microsoft - `ttf-mscorefonts-installer` и набора шрифтов Liberation в виде пакета `fonts-liberation`.

Добавилось два файла:

1. `Dockerfile` с описанием модификации контейнера;
2. `install-dockertex.sh` со скриптом автоматизированной установки Docker и dockertex в систему. Для удобства пользователя он задает версию контейнера переменной окружения и сохраняет его в соответствующих файлах - `~/.profile` и `~/.bashrc`.

Актуализировано содержимое файла `Readme/Installation.md`:

* добавлено описание установки контейнера;
* для Ubuntu не-LTS описана установка для 19.04 с обновлением списка пакетов;
* для Ubuntu LTS теперь рекомендовано применение контейнера Docker;
* для Debian поднята версия до 10-й, в которой все работает без контейнера; убрано упоминание файла `impnattypo.sty`, поскольку доподлинно известно что он содержится в пакете [`texlive-lang-french`](https://packages.debian.org/search?suite=buster&arch=any&mode=path&searchon=contents&keywords=impnattypo.sty) во всех версиях.

Если изменения будут приняты, то следующим шагом будет правка [соответствующей страницы Wiki](https://github.com/AndreyAkinshin/Russian-Phd-LaTeX-Dissertation-Template/wiki/Installation).
