### PR TITLE
поправлена прекомпиляция изображений из Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,7 @@ acs-*.bib
 # Comment the next line if you want to keep your tikz graphics files
 *.tikz
 *-tikzDictionary
+images/cache/**
 
 # listings
 *.lol

--- a/Dissertation/dispackages.tex
+++ b/Dissertation/dispackages.tex
@@ -7,16 +7,3 @@
 
 %%% Списки %%%
 \usepackage{enumitem}
-
-\usepackage{tikz}                   % Продвинутый пакет векторной графики
-\usetikzlibrary{chains}             % Для примера tikz рисунка
-\usetikzlibrary{shapes.geometric}   % Для примера tikz рисунка
-\usetikzlibrary{shapes.symbols}     % Для примера tikz рисунка
-\usetikzlibrary{arrows}             % Для примера tikz рисунка
-\ifnumequal{\value{imgprecompile}}{1}{% Только если у нас включена предкомпиляция
-    \usetikzlibrary{external}   % подключение возможности предкомпиляции
-    \tikzexternalize[prefix=Dissertation/images/] % activate! % здесь можно указать отдельную папку для скомпилированных файлов
-    \ifxetex
-        \tikzset{external/up to date check={diff}}
-    \fi
-}{}

--- a/Dissertation/part2.tex
+++ b/Dissertation/part2.tex
@@ -67,7 +67,7 @@
 то~для подготовки научных публикаций.
 \begin{figure}[ht]
     \centerfloat{
-        \ifdefmacro{\tikzsetnextfilename}{\tikzsetnextfilename{tikz_example_compiled}}{}% присваиваемое предкомпилированному pdf имя файла
+        \ifdefmacro{\tikzsetnextfilename}{\tikzsetnextfilename{tikz_example_compiled}}{}% присваиваемое предкомпилированному pdf имя файла (не обязательно)
         \input{Dissertation/images/tikz_scheme.tikz}
 
     }

--- a/Presentation/content.tex
+++ b/Presentation/content.tex
@@ -95,6 +95,14 @@
     \includegraphics[width=0.8\linewidth]{latex} % окружение figure не требуется
 \end{frame}
 
+\begin{frame}
+    \frametitle{Векторная графика}
+    \centering
+   \ifdefmacro{\tikzsetnextfilename}{\tikzsetnextfilename{tikz_presentation}}{}% присваиваемое предкомпилированному pdf имя файла (не обязательно)
+   \input{Presentation/images/tikz_plot.tikz}
+
+\end{frame}
+
 \subsection{Расположение}
 
 \begin{frame}

--- a/Presentation/images/tikz_plot.tikz
+++ b/Presentation/images/tikz_plot.tikz
@@ -1,0 +1,22 @@
+\begin{tikzpicture}
+  \draw[<->,thick] (0,6) -- (0,0) -- (10,0); % axis
+  \draw[help lines] (3,0) -- (3,5); % fill end
+  \draw[help lines] (6,0) -- (6,5); % flattop end
+  \draw[help lines] (9,0) -- (9,5); % decay end
+  \draw[<->, thin] (0,5) -- (3,5); % fill
+  \draw[<->, thin] (3,5) -- (6,5); % flattop
+  \draw[<->, thin] (6,5) -- (9,5); % decay
+  \draw[blue, ultra thick] (0,0) -- (0,4) -- (6,4) -- (6,0); % power
+  \draw[red, ultra thick, domain=0:3] plot (\x, {4*(1 - exp(-1.5*\x))}); % fill plot
+  \draw[red, ultra thick, domain=3:6] plot (\x, {4*(1 - exp(-1.5*\x))}); % flattop plot
+  \draw[red, ultra thick, domain=6:9.5] plot (\x, {4*(1 - exp(-9)) - 4*(1 - exp(-1.5*\x+9))}); % decay plot
+  \node [above] at (0,6) {\(E_\textup{ус}\)};
+  \node [right] at (10,0) {\(t\)};
+  \node at (1.5,5.4) {заполнение};
+  \node at (4.5,5.4) {работа};
+  \node at (7.5,5.4) {затухание};
+  \node at (4.5,1.4) {пучки};
+  \foreach \x in {3.1,3.3,...,5.9} {
+    \draw[->, green, thick] (\x,0) -- (\x,1);
+  }
+\end{tikzpicture}

--- a/Presentation/prespackages.tex
+++ b/Presentation/prespackages.tex
@@ -5,7 +5,7 @@
 \usepackage{enumerate,float,indentfirst}
 \usepackage{appendixnumberbeamer} % не считать номера страниц после команды \appendix
 \usepackage{array, booktabs} % для таблиц
-\usepackage{pgfpages,tikz}
+\usepackage{pgfpages}
 \usepackage{esint} % various fancy integral symbols
 
 \graphicspath{{images/}{Presentation/images/}} % папки с графикой

--- a/common/packages.tex
+++ b/common/packages.tex
@@ -193,3 +193,24 @@
 %%% Цитата, не приводимая в автореферате:
 % возможно, актуальна только для biblatex
 %\newcommand{\citeinsynopsis}[1]{\ifsynopsis\else ~\cite{#1} \fi}
+
+%% Векторная графика
+
+\usepackage{tikz}                   % Продвинутый пакет векторной графики
+\usetikzlibrary{chains}             % Для примера tikz рисунка
+\usetikzlibrary{shapes.geometric}   % Для примера tikz рисунка
+\usetikzlibrary{shapes.symbols}     % Для примера tikz рисунка
+\usetikzlibrary{arrows}             % Для примера tikz рисунка
+
+% если текущий процесс запущен библиотекой tikz-external, то прекомпиляция должна быть включена
+\ifdefined\tikzexternalrealjob
+    \setcounter{imgprecompile}{1}
+\fi
+
+\ifnumequal{\value{imgprecompile}}{1}{% Только если у нас включена предкомпиляция
+    \usetikzlibrary{external}   % подключение возможности предкомпиляции
+    \tikzexternalize[prefix=images/cache/] % activate! % здесь можно указать отдельную папку для скомпилированных файлов
+    \ifxetex
+        \tikzset{external/up to date check={diff}}
+    \fi
+}{}

--- a/images/cache/placeholder.txt
+++ b/images/cache/placeholder.txt
@@ -1,0 +1,2 @@
+placeholder for overleaf.
+see https://www.overleaf.com/learn/latex/Questions/I_have_a_lot_of_tikz,_matlab2tikz_or_pgfplots_figures,_so_I%27m_getting_a_compilation_timeout._Can_I_externalise_my_figures%3F


### PR DESCRIPTION
При прекомпиляции изображений библиотека [`tex-external`](http://mirror.macomnet.net/pub/CTAN/graphics/pgf/base/doc/pgfmanual.pdf) запускает дочерний процесс `latex` для генерации изображений. Если прекомпиляция была включена из командной строки при помощи `IMGCOMPILE=1`, а в `common/setup.tex` она отключена, то в дочернем процессе значение`imgprecompile` будет равно `0`, из-за чего библиотека `tex-external` в нём будет отключена. Вместо изображения в конечный файл будет добавлен весь документ (то, что влезет на одну страницу):

![image](https://user-images.githubusercontent.com/26824900/63271858-ae39eb80-c2a3-11e9-8d19-1af5e3464356.png)

В данном PR добавлено автоматическое переключение флага `imgprecompile` при определении данного процесса как дочернего при помощи проверки наличия `\tikzexternalrealjob`:

```
\tikzexternalrealjob
    After the library is loaded, this macro will always contain the correct main job’s
    name (in the example above, it is main)...
```