### PR TITLE
изменён вызов прекомпиляции в latexmkrc

### DIFF
--- a/latexmkrc
+++ b/latexmkrc
@@ -41,7 +41,7 @@ if ($IMGCOMPILE ne '') {
     $texargs = $texargs . '\newcounter{imgprecompile}' .
         '\setcounter{imgprecompile}' . '{' . $IMGCOMPILE . '}';
 }
-if ($IMGCOMPILE eq '1') {
+if ($IMGCOMPILE ne '') {
    $LATEXFLAGS = $LATEXFLAGS . ' -shell-escape'
 }
 if ($NOTESON ne '') {


### PR DESCRIPTION
Вызов прекомпиляции изображений в `latexmk` приведён в соответствие с аналогичными командами в этом файле. Избавляет от ошибок в случае запуска `make IMGCOMPILE=y`.