### PR TITLE
use media=text by default

### DIFF
--- a/biblio/biblatex.tex
+++ b/biblio/biblatex.tex
@@ -94,6 +94,9 @@ sorting=none,% настройка сортировки списка литера
             \step[fieldset=media, fieldvalue=eresource]
             \step[fieldset=medium, null]
         }
+        \map{% использование media=text по умолчанию
+            \step[fieldset=media, fieldvalue=text]
+        }
         \map[overwrite]{% стираем значения всех полей issn
             \step[fieldset=issn, null]
         }


### PR DESCRIPTION
Подавляющее большинство ссылок обычно идёт на текст статей, книг и т.д. В связи с этим оправданным является использование типа материала `media=text` по-умолчанию.