### PR TITLE
добавлен пакет units и пример subequations

### DIFF
--- a/Dissertation/part1.tex
+++ b/Dissertation/part1.tex
@@ -254,6 +254,24 @@ test:eisner-sample-shorted, AB_patent_Pomerantz_1968, iofis_patent1960}
 (\labelcref{eq:equation1, eq:equation3, eq:equation2}), даже перепутав
 порядок ссылок \verb|(\labelcref{eq:equation1, eq:equation3, eq:equation2})|.
 
+Уравнения~(\labelcref{eq:subeq_1,eq:subeq_2}) демонстрируют возможности
+окружения \verb|\subequations|.
+\begin{subequations}
+	\label{eq:subeq_1}
+	\begin{gather}
+		y = x^2 + 1 \label{eq:subeq_1-1} \\
+		y = 2 x^2 - x + 1 \label{eq:subeq_1-2}
+	\end{gather}
+\end{subequations}
+Ссылки на отдельные уравнения~(\labelcref{eq:subeq_1-1,eq:subeq_1-2,eq:subeq_2-1}).
+\begin{subequations}
+	\label{eq:subeq_2}
+	\begin{align}
+		y &= x^3 + x^2 + x + 1 \label{eq:subeq_2-1} \\
+		y &= x^2
+	\end{align}
+\end{subequations}
+
 \subsection{Форматирование чисел и размерностей величин}\label{sec:units}
 
 Числа форматируются при помощи команды \verb|\num|:

--- a/Dissertation/part1.tex
+++ b/Dissertation/part1.tex
@@ -254,26 +254,190 @@ test:eisner-sample-shorted, AB_patent_Pomerantz_1968, iofis_patent1960}
 (\labelcref{eq:equation1, eq:equation3, eq:equation2}), даже перепутав
 порядок ссылок \verb|(\labelcref{eq:equation1, eq:equation3, eq:equation2})|.
 
-\subsection{Размерности величин}\label{sec:units}
+\subsection{Форматирование чисел и размерностей величин}\label{sec:units}
 
-Размерности величин можно писать в строчку, например 1\,м/с, 20\,\(\frac{\textup{Н}}{\textup{м}}\).
-Лучшего результата можно добиться, используя функции пакета \verb|units|:
-\unit{м}; \unit[1]{см}; \unit[2,3]{мм}; \unitfrac[5]{мг}{л}; \unitfrac[100]{км}{ч}; \unitfrac[999,87]{кг}{\(\textup{м}^3\)}.
-Те-же команды работают в математических окружениях:
-\(\unitfrac[5]{км}{ч} = \frac{\unit[10^4]{м}}{\unit[2]{ч}}\);
+Числа форматируются при помощи команды \verb|\num|:
+\num{5,3};
+\num{2,3e8};
+\num{12345,67890};
+\num{2,6 d4};
+\num{1+-2i};
+\num{.3e45};
+\num[exponent-base=2]{5 e64};
+\num[exponent-base=2,exponent-to-prefix]{5 e64};
+\num{1.654 x 2.34 x 3.430}
+\num{1 2 x 3 / 4}.
+Для написания последовательности чисел можно использовать команды \verb|\numlist| и \verb|\numrange|:
+\numlist{10;30;50;70}; \numrange{10}{30}.
+Значения углов можно форматировать при помощи команды \verb|\ang|:
+\ang{2.67};
+\ang{30,3};
+\ang{-1;;};
+\ang{;-2;};
+\ang{;;-3};
+\ang{300;10;1}.
 
-\begin{subequations}
-        \begin{align}
-                \vec F = \frac{1}{4 \pi \varepsilon_0}&\frac{q_1 q_2}{|\vec r|^2} \frac{\vec r}{|\vec r|}; \label{eq:unit_example} \\
-                [F] &= \unit{Н}; \label{eq:unit_example-f} \\
-                [\varepsilon_0] &= \unitfrac{Гн}{м}; \label{eq:unit_example-eps} \\
-                [q_1], [q_2] &= \unit{Кл}; \label{eq:unit_example-q} \\
-                [r] &= \unit{м}, \label{eq:unit_example-r}
-        \end{align}
-\end{subequations}
-где~\eqref{eq:unit_example} "--- уравнение, (\labelcref{eq:unit_example-f,eq:unit_example-eps,eq:unit_example-q,
-eq:unit_example-r}) "--- размерности величин.
+Обратите внимание, что ГОСТ запрещает использование знака <<->> для обозначения отрицательных чисел
+за исключением формул, таблиц и рисунков.
+Вместо него следует использовать слово <<минус>>.
 
-Для написания дробей можно использовать команду \verb|\nicefrac|: \nicefrac{1}{2}; \nicefrac{2,2}{3,5}.
-В качестве дополнительного аргумента можно использовать различные команды форматирования:
-\nicefrac[\texttt]{1}{2}; \nicefrac[\textit]{1}{2}; \nicefrac[\textbf]{1}{2}.
+Размерности можно записывать при помощи команд \verb|\si| и \verb|\SI|:
+\si{\farad\squared\lumen\candela};
+\si{\joule\per\mole\per\kelvin};
+\si{\metre\per\second\squared};
+\SI{1.2-3i e5}{\joule\per\mole\per\kelvin};
+\SI{0.10(5)}{\neper};
+\SIlist{1;2;3;4}{\tesla};
+\SIrange{50}{100}{\volt}.
+Список единиц измерений приведён в таблицах~(\labelcref{tab:unit:base,
+	tab:unit:derived,tab:unit:accepted,tab:unit:physical,tab:unit:other}).
+Приставки единиц приведены в таблице~\ref{tab:unit:prefix}.
+
+С дополнительными опциями форматирования можно ознакомиться в описании пакета \texttt{siunitx};
+изменить или добавить единицы измерений можно в файле \texttt{siunitx.cfg}.
+
+\begin{table}
+    \caption{Основные величины СИ.}\label{tab:unit:base}
+    \centering
+    \begin{tabular}{llc}
+        \toprule
+        Название  & Команда                & Символ         \\
+        \midrule
+        Ампер     & \verb|\ampere| & \si{\ampere}   \\
+        Кандела   & \verb|\candela| & \si{\candela}  \\
+        Кельвин   & \verb|\kelvin| & \si{\kelvin}   \\
+        Килограмм & \verb|\kilogram| & \si{\kilogram} \\
+        Метр      & \verb|\metre| & \si{\metre}    \\
+        Моль      & \verb|\mole| & \si{\mole}     \\
+        Секунда   & \verb|\second| & \si{\second}   \\
+        \bottomrule
+    \end{tabular}
+\end{table}
+
+\begin{table}
+    \caption{Производные единицы СИ.}\label{tab:unit:derived}
+    \small
+    \centering
+    \begin{tabular}{llc|llc}
+        \toprule
+        Название       & Команда                 & Символ              & Название & Команда & Символ \\
+        \midrule
+        Беккерель      & \verb|\becquerel|  & \si{\becquerel}     &
+        Ньютон         & \verb|\newton|  & \si{\newton}                                      \\
+        Градус Цельсия & \verb|\degreeCelsius| & \si{\degreeCelsius} &
+        Ом             & \verb|\ohm| & \si{\ohm}                                         \\
+        Кулон          & \verb|\coulomb| & \si{\coulomb}       &
+        Паскаль        & \verb|\pascal| & \si{\pascal}                                      \\
+        Фарад          & \verb|\farad| & \si{\farad}         &
+        Радиан         & \verb|\radian| & \si{\radian}                                      \\
+        Грей           & \verb|\gray| & \si{\gray}          &
+        Сименс         & \verb|\siemens| & \si{\siemens}                                     \\
+        Герц           & \verb|\hertz| & \si{\hertz}         &
+        Зиверт         & \verb|\sievert| & \si{\sievert}                                     \\
+        Генри          & \verb|\henry| & \si{\henry}         &
+        Стерадиан      & \verb|\steradian| & \si{\steradian}                                   \\
+        Джоуль         & \verb|\joule| & \si{\joule}         &
+        Тесла          & \verb|\tesla| & \si{\tesla}                                       \\
+        Катал          & \verb|\katal| & \si{\katal}         &
+        Вольт          & \verb|\volt| & \si{\volt}                                        \\
+        Люмен          & \verb|\lumen| & \si{\lumen}         &
+        Ватт           & \verb|\watt| & \si{\watt}                                        \\
+        Люкс           & \verb|\lux| & \si{\lux}           &
+        Вебер          & \verb|\weber| & \si{\weber}                                       \\
+        \bottomrule
+    \end{tabular}
+\end{table}
+
+\begin{table}
+    \caption{Внесистемные единицы.}\label{tab:unit:accepted}
+    \centering
+    \begin{tabular}{llc}
+        \toprule
+        Название        & Команда                 & Символ          \\
+        \midrule
+        День            & \verb|\day| & \si{\day}       \\
+        Градус          & \verb|\degree| & \si{\degree}    \\
+        Гектар          & \verb|\hectare| & \si{\hectare}   \\
+        Час             & \verb|\hour| & \si{\hour}      \\
+        Литр            & \verb|\litre| & \si{\litre}     \\
+        Угловая минута  & \verb|\arcminute| & \si{\arcminute} \\
+        Угловая секунда & \verb|\arcsecond| & \si{\arcsecond} \\ %
+        Минута          & \verb|\minute| & \si{\minute}    \\
+        Тонна           & \verb|\tonne| & \si{\tonne}     \\
+        \bottomrule
+    \end{tabular}
+\end{table}
+
+\begin{table}
+    \caption{Внесистемные единицы, получаемые из эксперимента.}\label{tab:unit:physical}
+    \centering
+    \begin{tabular}{llc}
+        \toprule
+        Название                & Команда                 & Символ                 \\
+        \midrule
+        Астрономическая единица & \verb|\astronomicalunit| & \si{\astronomicalunit} \\
+        Атомная единица массы   & \verb|\atomicmassunit| & \si{\atomicmassunit}   \\
+        Боровский радиус        & \verb|\bohr| & \si{\bohr}             \\
+        Скорость света          & \verb|\clight| & \si{\clight}           \\
+        Дальтон                 & \verb|\dalton| & \si{\dalton}           \\
+        Масса электрона         & \verb|\electronmass| & \si{\electronmass}     \\
+        Электрон Вольт          & \verb|\electronvolt| & \si{\electronvolt}     \\
+        Элементарный заряд      & \verb|\elementarycharge| & \si{\elementarycharge} \\
+        Энергия Хартри          & \verb|\hartree| & \si{\hartree}          \\
+        Постоянная Планка       & \verb|\planckbar| & \si{\planckbar}        \\
+        \bottomrule
+    \end{tabular}
+\end{table}
+
+\begin{table}
+    \caption{Другие внесистемные единицы.}\label{tab:unit:other}
+    \centering
+    \begin{tabular}{llc}
+        \toprule
+        Название                  & Команда                 & Символ             \\
+        \midrule
+        Ангстрем                  & \verb|\angstrom| & \si{\angstrom}     \\
+        Бар                       & \verb|\bar| & \si{\bar}          \\
+        Барн                      & \verb|\barn| & \si{\barn}         \\
+        Бел                       & \verb|\bel| & \si{\bel}          \\
+        Децибел                   & \verb|\decibel| & \si{\decibel}      \\
+        Узел                      & \verb|\knot| & \si{\knot}         \\
+        Миллиметр ртутного столба & \verb|\mmHg| & \si{\mmHg}         \\
+        Морская миля              & \verb|\nauticalmile| & \si{\nauticalmile} \\
+        Непер                     & \verb|\neper| & \si{\neper}        \\
+        \bottomrule
+    \end{tabular}
+\end{table}
+
+\begin{table}
+    \caption{Приставки СИ.}\label{tab:unit:prefix}
+    \centering
+    \small
+    \begin{tabular}{llcc|llcc}
+        \toprule
+        Приставка & Команда                 & Символ      & Степень &
+        Приставка & Команда                 & Символ      & Степень   \\
+        \midrule
+        Иокто     & \verb|\yocto| & \si{\yocto} & -24     &
+        Дека      & \verb|\deca| & \si{\deca}  & 1         \\
+        Зепто     & \verb|\zepto| & \si{\zepto} & -21     &
+        Гекто     & \verb|\hecto| & \si{\hecto} & 2         \\
+        Атто      & \verb|\atto| & \si{\atto}  & -18     &
+        Кило      & \verb|\kilo| & \si{\kilo}  & 3         \\
+        Фемто     & \verb|\femto| & \si{\femto} & -15     &
+        Мега      & \verb|\mega| & \si{\mega}  & 6         \\
+        Пико      & \verb|\pico| & \si{\pico}  & -12     &
+        Гига      & \verb|\giga| & \si{\giga}  & 9         \\
+        Нано      & \verb|\nano| & \si{\nano}  & -9      &
+        Терра     & \verb|\tera| & \si{\tera}  & 12        \\
+        Микро     & \verb|\micro| & \si{\micro} & -6      &
+        Пета      & \verb|\peta| & \si{\peta}  & 15        \\
+        Милли     & \verb|\milli| & \si{\milli} & -3      &
+        Екса      & \verb|\exa| & \si{\exa}   & 18        \\
+        Санти     & \verb|\centi| & \si{\centi} & -2      &
+        Зетта     & \verb|\zetta| & \si{\zetta} & 21        \\
+        Деци      & \verb|\deci| & \si{\deci}  & -1      &
+        Иотта     & \verb|\yotta| & \si{\yotta} & 24        \\
+        \bottomrule
+    \end{tabular}
+\end{table}

--- a/Dissertation/part1.tex
+++ b/Dissertation/part1.tex
@@ -109,11 +109,6 @@ test:eisner-sample-shorted, AB_patent_Pomerantz_1968, iofis_patent1960}
 \Delta\Theta\Lambda\Xi\Pi\Sigma\Upsilon\Phi\Psi\Omega}
 \]
 
-Для красивых дробей (например, в индексах) в
-\verb+userstyles.tex+ диссертации добавлен макрос
-\verb+\slantfrac+, благодаря которому можно
-писать \(\slantfrac{1}{2}\) вместо \(1/2\).
-
 Для добавления формул можно использовать пары \verb+$+\dots\verb+$+ и \verb+$$+\dots\verb+$$+,
 но~они считаются устаревшими.
 Лучше использовать их функциональные аналоги \verb+\(+\dots\verb+\)+ и \verb+\[+\dots\verb+\]+.
@@ -258,3 +253,27 @@ test:eisner-sample-shorted, AB_patent_Pomerantz_1968, iofis_patent1960}
 красиво ссылаться сразу на несколько формул
 (\labelcref{eq:equation1, eq:equation3, eq:equation2}), даже перепутав
 порядок ссылок \verb|(\labelcref{eq:equation1, eq:equation3, eq:equation2})|.
+
+\subsection{Размерности величин}\label{sec:units}
+
+Размерности величин можно писать в строчку, например 1\,м/с, 20\,\(\frac{\textup{Н}}{\textup{м}}\).
+Лучшего результата можно добиться, используя функции пакета \verb|units|:
+\unit{м}; \unit[1]{см}; \unit[2,3]{мм}; \unitfrac[5]{мг}{л}; \unitfrac[100]{км}{ч}; \unitfrac[999,87]{кг}{\(\textup{м}^3\)}.
+Те-же команды работают в математических окружениях:
+\(\unitfrac[5]{км}{ч} = \frac{\unit[10^4]{м}}{\unit[2]{ч}}\);
+
+\begin{subequations}
+        \begin{align}
+                \vec F = \frac{1}{4 \pi \varepsilon_0}&\frac{q_1 q_2}{|\vec r|^2} \frac{\vec r}{|\vec r|}; \label{eq:unit_example} \\
+                [F] &= \unit{Н}; \label{eq:unit_example-f} \\
+                [\varepsilon_0] &= \unitfrac{Гн}{м}; \label{eq:unit_example-eps} \\
+                [q_1], [q_2] &= \unit{Кл}; \label{eq:unit_example-q} \\
+                [r] &= \unit{м}, \label{eq:unit_example-r}
+        \end{align}
+\end{subequations}
+где~\eqref{eq:unit_example} "--- уравнение, (\labelcref{eq:unit_example-f,eq:unit_example-eps,eq:unit_example-q,
+eq:unit_example-r}) "--- размерности величин.
+
+Для написания дробей можно использовать команду \verb|\nicefrac|: \nicefrac{1}{2}; \nicefrac{2,2}{3,5}.
+В качестве дополнительного аргумента можно использовать различные команды форматирования:
+\nicefrac[\texttt]{1}{2}; \nicefrac[\textit]{1}{2}; \nicefrac[\textbf]{1}{2}.

--- a/Dissertation/part3.tex
+++ b/Dissertation/part3.tex
@@ -201,6 +201,46 @@
     \end{tabularx}%
 \end{table}
 
+\section{Таблицы с форматированными числами}\label{sec:ch3/formatted-numbers}
+
+В таблицах~(\labelcref{tab:S:parse,tab:S:align}) представлены примеры использования опции
+форматирования чисел \texttt{S}, предоставляемой пакетом \texttt{siunitx}.
+
+\begin{table}
+    \centering
+    \caption{Выравнивание столбцов.}\label{tab:S:parse}
+    \begin{tabular}{SS[table-parse-only]}
+        \toprule
+        {Выравнивание по разделителю} & {Обычное выравнивание} \\
+        \midrule
+        12.345                        & 12.345                 \\
+        6,78                          & 6,78                   \\
+        -88.8(9)                      & -88.8(9)               \\
+        4.5e3                         & 4.5e3                  \\
+        \bottomrule
+    \end{tabular}
+\end{table}
+
+\begin{table}
+    \caption{Выравнивание с использованием опции \texttt{S}.}\label{tab:S:align}
+    \centering
+    \sisetup{
+        table-figures-integer = 2,
+        table-figures-decimal = 4
+    }
+    \begin{tabular}
+        {SS[table-number-alignment = center]S[table-number-alignment = left]S[table-number-alignment = right]}
+        \toprule
+        {Колонка 1} & {Колонка 2} & {Колонка 3} & {Колонка 4} \\
+        \midrule
+        2.3456      & 2.3456      & 2.3456      & 2.3456      \\
+        34.2345     & 34.2345     & 34.2345     & 34.2345     \\
+        56.7835     & 56.7835     & 56.7835     & 56.7835     \\
+        90.473      & 90.473      & 90.473      & 90.473      \\
+        \bottomrule
+    \end{tabular}
+\end{table}
+
 \section{Параграф "--- два}\label{sec:ch3/sect2}
 
 Некоторый текст.

--- a/Dissertation/userstyles.tex
+++ b/Dissertation/userstyles.tex
@@ -309,7 +309,3 @@
 \renewcommand{\chi}{\upchi}
 \renewcommand{\psi}{\uppsi}
 \renewcommand{\omega}{\upomega}
-
-\def\slantfrac#1#2{ \hspace{3pt}\!^{#1}\!\!\hspace{1pt}/
-    \hspace{2pt}\!\!_{#2}\!\hspace{3pt}
-} %Макрос для красивых дробей в строчку (например, 1/2)

--- a/Presentation/prespackages.tex
+++ b/Presentation/prespackages.tex
@@ -16,8 +16,4 @@
 \newcommand*{\rom}[1]{\expandafter\@slowromancap\romannumeral#1@}
 \makeatother
 
-\def\slantfrac#1#2{ \hspace{3pt}\!^{#1}\!\!\hspace{1pt}/
-\hspace{2pt}\!\!_{#2}\!\hspace{3pt}
-} %Макрос для красивых дробей в строчку (например, 1/2)
-
 \newcommand{\itemi}{\item[\checkmark]}

--- a/common/packages.tex
+++ b/common/packages.tex
@@ -24,6 +24,12 @@
 \usepackage{amsthm,amsmath,amscd}   % Математические дополнения от AMS
 \usepackage{amsfonts,amssymb}       % Математические дополнения от AMS
 \usepackage{mathtools}              % Добавляет окружение multlined
+\usepackage{units}                  % Красивые дроби и размерности
+
+% Кириллица в нумерации subequations
+\patchcmd{\subequations}{\def\theequation{\theparentequation\alph{equation}}}
+{\def\theequation{\theparentequation\asbuk{equation}}}
+{\typeout{subequations patched}}{\typeout{subequations not patched}}
 
 %%%% Установки для размера шрифта 14 pt %%%%
 %% Формирование переменных и констант для сравнения (один раз для всех подключаемых файлов)%%

--- a/common/packages.tex
+++ b/common/packages.tex
@@ -24,12 +24,17 @@
 \usepackage{amsthm,amsmath,amscd}   % Математические дополнения от AMS
 \usepackage{amsfonts,amssymb}       % Математические дополнения от AMS
 \usepackage{mathtools}              % Добавляет окружение multlined
-\usepackage{units}                  % Красивые дроби и размерности
-
-% Кириллица в нумерации subequations
-\patchcmd{\subequations}{\def\theequation{\theparentequation\alph{equation}}}
-{\def\theequation{\theparentequation\asbuk{equation}}}
-{\typeout{subequations patched}}{\typeout{subequations not patched}}
+\usepackage{xfrac}                  % Красивые дроби
+\usepackage[
+    locale = DE,
+    list-separator       = {;\,},
+    list-final-separator = {;\,},
+    list-pair-separator  = {;\,},
+    range-phrase         = {--},
+    % quotient-mode        = fraction, % красивые дроби могут не соответствовать ГОСТ
+    fraction-function    = \sfrac,
+    separate-uncertainty,
+    ]{siunitx}                      % Размерности SI
 
 %%%% Установки для размера шрифта 14 pt %%%%
 %% Формирование переменных и констант для сравнения (один раз для всех подключаемых файлов)%%

--- a/common/packages.tex
+++ b/common/packages.tex
@@ -30,7 +30,7 @@
     list-separator       = {;\,},
     list-final-separator = {;\,},
     list-pair-separator  = {;\,},
-    range-phrase         = {--},
+    range-phrase         = {\text{\ensuremath{-}}},
     % quotient-mode        = fraction, % красивые дроби могут не соответствовать ГОСТ
     fraction-function    = \sfrac,
     separate-uncertainty,

--- a/common/packages.tex
+++ b/common/packages.tex
@@ -36,6 +36,12 @@
     separate-uncertainty,
     ]{siunitx}                      % Размерности SI
 
+% Кириллица в нумерации subequations
+% Для правильной работы требуется выполнение сразу после загрузки пакетов
+\patchcmd{\subequations}{\def\theequation{\theparentequation\alph{equation}}}
+{\def\theequation{\theparentequation\asbuk{equation}}}
+{\typeout{subequations patched}}{\typeout{subequations not patched}}
+
 %%%% Установки для размера шрифта 14 pt %%%%
 %% Формирование переменных и констант для сравнения (один раз для всех подключаемых файлов)%%
 %% должно располагаться до вызова пакета fontspec или polyglossia, потому что они сбивают его работу

--- a/common/styles.tex
+++ b/common/styles.tex
@@ -121,8 +121,3 @@
 \setlist{nosep,%                                    % Единый стиль для всех списков (пакет enumitem), без дополнительных интервалов.
     labelindent=\parindent,leftmargin=*%            % Каждый пункт, подпункт и перечисление записывают с абзацного отступа (ГОСТ 2.105-95, 4.1.8)
 }
-
-% Кириллица в нумерации subequations
-\patchcmd{\subequations}{\def\theequation{\theparentequation\alph{equation}}}
-{\def\theequation{\theparentequation\asbuk{equation}}}
-{\typeout{subequations patched}}{\typeout{subequations not patched}}

--- a/common/styles.tex
+++ b/common/styles.tex
@@ -121,3 +121,8 @@
 \setlist{nosep,%                                    % Единый стиль для всех списков (пакет enumitem), без дополнительных интервалов.
     labelindent=\parindent,leftmargin=*%            % Каждый пункт, подпункт и перечисление записывают с абзацного отступа (ГОСТ 2.105-95, 4.1.8)
 }
+
+% Кириллица в нумерации subequations
+\patchcmd{\subequations}{\def\theequation{\theparentequation\alph{equation}}}
+{\def\theequation{\theparentequation\asbuk{equation}}}
+{\typeout{subequations patched}}{\typeout{subequations not patched}}

--- a/siunitx.cfg
+++ b/siunitx.cfg
@@ -1,0 +1,105 @@
+\ProvidesFile{siunitx.cfg}
+% Put any \sisetup{} command here too
+\DeclareSIUnit{\KWH}{кВт\,ч}
+\DeclareSIUnit \metre    { м }
+\DeclareSIUnit \mole     { моль }
+\DeclareSIUnit \second   { с }
+\DeclareSIUnit \ampere   { А }
+\DeclareSIUnit \kelvin   { К }
+\DeclareSIUnit \candela  { кд }
+\DeclareSIUnit \gram { г }
+\DeclareSIPrefix \yocto { и } { -24 }
+\DeclareSIPrefix \zepto { з } { -21 }
+\DeclareSIPrefix \atto  { а } { -18 }
+\DeclareSIPrefix \femto { ф } { -15 }
+\DeclareSIPrefix \pico  { п } { -12 }
+\DeclareSIPrefix \nano  { н } { -9 }
+\DeclareSIPrefix \micro { мк } { -6 }
+\DeclareSIPrefix \milli { м } { -3 }
+\DeclareSIPrefix \centi { с } { -2 }
+\DeclareSIPrefix \deci  { д } { -1 }
+\DeclareSIPrefix \deca  { да } { 1 }
+\DeclareSIPrefix \deka  { да } { 1 }
+\DeclareSIPrefix \hecto { г }  { 2 }
+\DeclareSIPrefix \kilo  { к }  { 3 }
+\DeclareSIPrefix \mega  { М }  { 6 }
+\DeclareSIPrefix \giga  { Г }  { 9 }
+\DeclareSIPrefix \tera  { Т }  { 12 }
+\DeclareSIPrefix \peta  { П }  { 15 }
+\DeclareSIPrefix \exa   { Э }  { 18 }
+\DeclareSIPrefix \zetta { З }  { 21 }
+\DeclareSIPrefix \yotta { И }  { 24 }
+\DeclareSIUnit \becquerel     { Бк }
+\DeclareSIUnit \celsius       { \SIUnitSymbolCelsius }
+\DeclareSIUnit \degreeCelsius { \SIUnitSymbolCelsius }
+\DeclareSIUnit \coulomb       { Кл }
+\DeclareSIUnit \farad         { Ф }
+\DeclareSIUnit \gray          { Гр }
+\DeclareSIUnit \hertz         { Гц }
+\DeclareSIUnit \henry         { Гн }
+\DeclareSIUnit \joule         { Дж }
+\DeclareSIUnit \katal         { кат }
+\DeclareSIUnit \lumen         { лм }
+\DeclareSIUnit \lux           { лк }
+\DeclareSIUnit \newton    { Н }
+\DeclareSIUnit \ohm       { Ом }
+\DeclareSIUnit \pascal    { Па }
+\DeclareSIUnit \radian    { рад }
+\DeclareSIUnit \siemens   { См }
+\DeclareSIUnit \sievert   { Зв }
+\DeclareSIUnit \steradian { ср }
+\DeclareSIUnit \tesla     { Тл }
+\DeclareSIUnit \volt      { В }
+\DeclareSIUnit \watt      { Вт }
+\DeclareSIUnit \weber     { Вб }
+\DeclareSIUnit [ number-unit-product = ] \arcmin { \arcminute }
+\DeclareSIUnit [ number-unit-product = ] \arcminute { \SIUnitSymbolArcminute }
+\DeclareSIUnit [ number-unit-product = ] \arcsecond { \SIUnitSymbolArcsecond }
+\DeclareSIUnit \day { d }
+\DeclareSIUnit[ number-unit-product = ]  \degree { \SIUnitSymbolDegree }
+\DeclareSIUnit \day { сут }
+\DeclareSIUnit \hectare { га }
+\DeclareSIUnit \hour    { ч }
+\DeclareSIUnit \litre   { л }
+\DeclareSIUnit \liter   { Л }
+\DeclareSIUnit \minute  { мин }
+\DeclareSIUnit \percent { \char 37 }
+\DeclareSIUnit \tonne   { т }
+\DeclareSIUnit \astronomicalunit { а.е. }
+\DeclareSIUnit \atomicmassunit   { а.е.м. }
+\DeclareSIUnit \electronvolt     { эВ }
+\DeclareSIUnit \dalton           { а.е.м. }
+\DeclareSIUnit \clight { \text { \ensuremath { c } } }
+\DeclareSIUnit \electronmass { \text { \ensuremath { m_{\textup{e}} } } }
+\DeclareSIUnit \planckbar { \text { \ensuremath { \hbar } } }
+\DeclareSIUnit \bohr { \text { \ensuremath { a_{0} } } }
+\DeclareSIUnit \hartree { \text { \ensuremath { E_{\textup{h}} } } }
+\DeclareSIUnit \angstrom     { \SIUnitSymbolAngstrom }
+\DeclareSIUnit \bar          { бар }
+\DeclareSIUnit \barn         { б }
+\DeclareSIUnit \bel          { Б }
+\DeclareSIUnit \knot         { уз }
+\DeclareSIUnit \mmHg         { мм.рт.ст. }
+\DeclareSIUnit \nauticalmile { миля }
+\DeclareSIUnit \neper        { Нп }
+\DeclareSIUnit \are      { а }
+\DeclareSIUnit \curie    { Ки }
+\DeclareSIUnit \gal      { Гал }
+\DeclareSIUnit \rad      { рад }
+\DeclareSIUnit \rem      { Бэр }
+\DeclareSIUnit \roentgen { Р }
+\DeclareSIUnit \parsec    { пк }
+\DeclareSIUnit \lightyear { св.\,год }
+\DeclareSIUnit \torr  { тор }
+\DeclareSIUnit \gon    { град }
+\DeclareSIUnit \gauss     { Гc }
+\DeclareBinaryPrefix \kibi { Ки } { 10 }
+\DeclareBinaryPrefix \mebi { Ми } { 20 }
+\DeclareBinaryPrefix \gibi { Ги } { 30 }
+\DeclareBinaryPrefix \tebi { Ти } { 40 }
+\DeclareBinaryPrefix \pebi { Пи } { 50 }
+\DeclareBinaryPrefix \exbi { Эи } { 60 }
+\DeclareBinaryPrefix \zebi { Зи } { 70 }
+\DeclareBinaryPrefix \yobi { Йи } { 80 }
+\DeclareSIUnit \bit  { бит }
+\DeclareSIUnit \byte { Б }


### PR DESCRIPTION
Макро `\slantfrac` заменено пакетом `units`. Добавлены примеры
применения.
Один из примеров также демонстрирует возможности команды `\subequations`

---

![image](https://user-images.githubusercontent.com/26824900/67719461-e7e54c00-f9e2-11e9-9a4b-ed23afadc6d0.png)
