### PR TITLE
Fix incorrect support of numero sign in russian pdflatex

### DIFF
--- a/biblio/biblatex.tex
+++ b/biblio/biblatex.tex
@@ -30,6 +30,12 @@ sorting=none,% настройка сортировки списка литера
 }
 \makeatother
 
+\ifxetexorluatex
+\else
+% Исправление случая неподдержки знака номера в pdflatex
+    \DefineBibliographyStrings{russian}{number={\textnumero}}
+\fi
+
 \ifsynopsis
 \ifnumgreater{\value{usefootcite}}{0}{
     \ExecuteBibliographyOptions{autocite=footnote}


### PR DESCRIPTION
Possible fix https://github.com/AndreyAkinshin/Russian-Phd-LaTeX-Dissertation-Template/issues/360
Possible fix https://github.com/AndreyAkinshin/Russian-Phd-LaTeX-Dissertation-Template/issues/372
Possible fix https://github.com/AndreyAkinshin/Russian-Phd-LaTeX-Dissertation-Template/issues/374

`make examples-pdflatex-cm` срабатывает корректно.

`pdflatex`, `inputenc`, `babel` или вообще кодировка T2A в 2019 году перестали в каких-то случаях нормально работать как минимум со знаком номера (№), что проявлялось в работе с biblatex-gost.
Решение проблемы подсказано в https://github.com/odomanov/biblatex-gost/issues/22#issuecomment-555391235