### PR TITLE
Русскоязычные источники предшествуют остальным

### DIFF
--- a/biblio/biblatex.tex
+++ b/biblio/biblatex.tex
@@ -402,6 +402,39 @@ sorting=none,% настройка сортировки списка литера
 \defbibheading{pubgroup}{\section*{#1}} % обычный стиль, заголовок-секция
 \defbibheading{pubsubgroup}{\noindent\textbf{#1}} % для подразделов "по типу источника"
 
+%%%Сортировка списка литературы Русский-Английский (предварительно удалить .bib) (начало)
+%\DeclareSourcemap{
+%	\maps[datatype=bibtex]{
+%		\map{
+%			\step[fieldset=langid, fieldvalue={tempruorder}]
+%		}
+%		\map[overwrite]{
+%			\step[fieldsource=langid, match=russian, final]
+%			\step[fieldsource=presort, 
+%			match=\regexp{(.+)}, 
+%			replace=\regexp{aa$1}]
+%		}
+%		\map{
+%			\step[fieldsource=langid, match=russian, final]
+%			\step[fieldset=presort, fieldvalue={az}]
+%		}
+%		\map[overwrite]{
+%			\step[fieldsource=langid, notmatch=russian, final]
+%			\step[fieldsource=presort, 
+%			match=\regexp{(.+)}, 
+%			replace=\regexp{za$1}]
+%		}
+%		\map{
+%			\step[fieldsource=langid, notmatch=russian, final]
+%			\step[fieldset=presort, fieldvalue={zz}]
+%		}
+%		\map{
+%			\step[fieldsource=langid, match={tempruorder}, final]
+%			\step[fieldset=langid, null]
+%		}
+%	}
+%}
+%Сортировка списка литературы (конец)
 
 %%% Создание команд для вывода списка литературы %%%
 \newcommand*{\insertbibliofull}{

--- a/biblio/biblatex.tex
+++ b/biblio/biblatex.tex
@@ -403,7 +403,7 @@ sorting=none,% настройка сортировки списка литера
 \defbibheading{pubsubgroup}{\noindent\textbf{#1}} % для подразделов "по типу источника"
 
 %%%Сортировка списка литературы Русский-Английский (предварительно удалить dissertation.bbl) (начало)
-%%%Источник: https://github.com/odomanov/biblatex-gost.wiki.git
+%%%Источник: https://github.com/odomanov/biblatex-gost/wiki/%D0%9A%D0%B0%D0%BA-%D1%81%D0%B4%D0%B5%D0%BB%D0%B0%D1%82%D1%8C,-%D1%87%D1%82%D0%BE%D0%B1%D1%8B-%D1%80%D1%83%D1%81%D1%81%D0%BA%D0%BE%D1%8F%D0%B7%D1%8B%D1%87%D0%BD%D1%8B%D0%B5-%D0%B8%D1%81%D1%82%D0%BE%D1%87%D0%BD%D0%B8%D0%BA%D0%B8-%D0%BF%D1%80%D0%B5%D0%B4%D1%88%D0%B5%D1%81%D1%82%D0%B2%D0%BE%D0%B2%D0%B0%D0%BB%D0%B8-%D0%BE%D1%81%D1%82%D0%B0%D0%BB%D1%8C%D0%BD%D1%8B%D0%BC
 %\DeclareSourcemap{
 %	\maps[datatype=bibtex]{
 %		\map{

--- a/biblio/biblatex.tex
+++ b/biblio/biblatex.tex
@@ -402,7 +402,8 @@ sorting=none,% настройка сортировки списка литера
 \defbibheading{pubgroup}{\section*{#1}} % обычный стиль, заголовок-секция
 \defbibheading{pubsubgroup}{\noindent\textbf{#1}} % для подразделов "по типу источника"
 
-%%%Сортировка списка литературы Русский-Английский (предварительно удалить .bib) (начало)
+%%%Сортировка списка литературы Русский-Английский (предварительно удалить dissertation.bbl) (начало)
+%%%Источник: https://github.com/odomanov/biblatex-gost.wiki.git
 %\DeclareSourcemap{
 %	\maps[datatype=bibtex]{
 %		\map{


### PR DESCRIPTION
Проверено на pdflatex через движок biber. [Взято тут](https://github.com/odomanov/biblatex-gost/wiki/%D0%9A%D0%B0%D0%BA-%D1%81%D0%B4%D0%B5%D0%BB%D0%B0%D1%82%D1%8C,-%D1%87%D1%82%D0%BE%D0%B1%D1%8B-%D1%80%D1%83%D1%81%D1%81%D0%BA%D0%BE%D1%8F%D0%B7%D1%8B%D1%87%D0%BD%D1%8B%D0%B5-%D0%B8%D1%81%D1%82%D0%BE%D1%87%D0%BD%D0%B8%D0%BA%D0%B8-%D0%BF%D1%80%D0%B5%D0%B4%D1%88%D0%B5%D1%81%D1%82%D0%B2%D0%BE%D0%B2%D0%B0%D0%BB%D0%B8-%D0%BE%D1%81%D1%82%D0%B0%D0%BB%D1%8C%D0%BD%D1%8B%D0%BC)