### PR TITLE
Решение проблемы со сборкой

### DIFF
--- a/common/packages.tex
+++ b/common/packages.tex
@@ -56,6 +56,7 @@
 
 %%% Кодировки и шрифты %%%
 \ifxetexorluatex
+    \PassOptionsToPackage{no-math}{fontspec}        % https://tex.stackexchange.com/a/26295/104425
     \usepackage{polyglossia}[2014/05/21]            % Поддержка многоязычности (fontspec подгружается автоматически)
 \else
    %%% Решение проблемы копирования текста в буфер кракозябрами


### PR DESCRIPTION
При сборке последней версии шаблона выводится ошибка:
```
Package fontspec Info: Adjusting the maths setup (use [no-math] to avoid
(fontspec)             this).

\symlegacymaths=\mathgroup7
LaTeX Font Info:    Overwriting symbol font `legacymaths' in version `bold'
(Font)                  OT1/cmr/m/n --> OT1/cmr/bx/n on input line 52.

./dissertation.tex:52: LaTeX Error: Command `\acute' already defined.
```

Решение проблемы при помощи <https://tex.stackexchange.com/a/26295/104425>