### PR TITLE
переименование \todo в \fixme для презентации

### DIFF
--- a/Presentation/prespackages.tex
+++ b/Presentation/prespackages.tex
@@ -10,7 +10,7 @@
 
 \graphicspath{{images/}{Presentation/images/}} % папки с графикой
 
-\DeclareRobustCommand{\todo}{\textcolor{red}}       % решаем проблему превращения названия цвета в результате \MakeUppercase, http://tex.stackexchange.com/a/187930, \DeclareRobustCommand protects \todo from expanding inside \MakeUppercase
+\DeclareRobustCommand{\fixme}{\textcolor{red}}       % решаем проблему превращения названия цвета в результате \MakeUppercase, http://tex.stackexchange.com/a/187930, \DeclareRobustCommand protects \todo from expanding inside \MakeUppercase
 
 \makeatletter
 \newcommand*{\rom}[1]{\expandafter\@slowromancap\romannumeral#1@}


### PR DESCRIPTION
Исправление ошибки из PR #402, описанной в  #404