### PR TITLE
изменение форматирования диапазонов чисел

### DIFF
--- a/common/packages.tex
+++ b/common/packages.tex
@@ -32,6 +32,8 @@
     list-separator       = {;\,},
     list-final-separator = {;\,},
     list-pair-separator  = {;\,},
+    list-units           = single,
+    range-units          = single,
     range-phrase={\text{\ensuremath{-}}},
     % quotient-mode        = fraction, % красивые дроби могут не соответствовать ГОСТ
     fraction-function    = \sfrac,


### PR DESCRIPTION
<!-- Подробнее об оформлении PR можно прочитать в документе https://github.com/AndreyAkinshin/Russian-Phd-LaTeX-Dissertation-Template/blob/master/CONTRIBUTING.md -->

## PR checklist

Пожалуйста, убедитесь, что Ваш PR удовлетворяет требованиям:

- [x] Изменения были протестированы (`make examples`)
- [ ] Изменения отражены в документации к шаблону
- [x] Код соответствует правилам индентации шаблона (`make indent`)


## Тип PR

Отметьте графы, которые относятся к данному PR:

- [x] Bugfix
- [ ] Feature
- [ ] Форматирование стиля кода
- [ ] Изменение текста шаблона
- [ ] Изменение документации
- [ ] Другое:


## Описание PR
<!-- Описание изменений. -->

Согласно [ГОСТ](https://github.com/AndreyAkinshin/Russian-Phd-LaTeX-Dissertation-Template/blob/master/Documents/GOST%202.105-95.pdf):

> 4.2.11 Если в тексте документа приводят диапазон числовых значений физической величины, выраженных в одной и той же единице физической величины, то обозначение единицы физической

В данном PR настройки пакета `siunitx` изменены, чтобы соответствовать этим требованиям.

## Смежные обсуждения
<!-- Ссылки на PR и issue, к которым относится данный PR. -->

Данный PR закрывает issue:

## Тестирование шаблона
<!-- Эта часть в будущем должна быть автоматизирована -->

Тестирование производилось в среде

- [ ] Windows
- [ ] Windows Cygwin
- [x] GNU/Linux (на основе Debian)
- [ ] GNU/Linux (на основе RedHat)
- [ ] Arch Linux
- [ ] Docker (ссылка на контейнер):

## Другая информация

![image](https://user-images.githubusercontent.com/26824900/82150879-39133b00-9862-11ea-814e-a13c97abf391.png)
