### PR TITLE
добавление переменной для управления сжатием рисунков в make

### DIFF
--- a/compress.mk
+++ b/compress.mk
@@ -34,32 +34,33 @@ COMPRESSION_FLAGS_COMMON += -dEmbedAllFonts=true -dSubsetFonts=true
 
 
 ### (1) Пересборка pdf для уменьшения размера, за счёт снижения качества картинок --------------------------
-# (крутить `-d*ImageResolution` до достижения приемлемого размера)
+# (крутить `COMPRESSION_IMAGE_DPI` до достижения приемлемого размера)
+COMPRESSION_IMAGE_DPI ?= 144
 COMPRESSION_FLAGS_1 = $(COMPRESSION_FLAGS_COMMON)
 
 COMPRESSION_FLAGS_1 += -dDownsampleColorImages=true
 COMPRESSION_FLAGS_1 += -dColorImageDownsampleThreshold=1.5
 COMPRESSION_FLAGS_1 += -dColorImageDownsampleType=/Average  # Bicubic может давать цветные артефакты
 COMPRESSION_FLAGS_1 += -dColorImageFilter=/DCTEncode        # /DCTEncode = jpg, lossy
-COMPRESSION_FLAGS_1 += -dColorImageResolution=144
+COMPRESSION_FLAGS_1 += -dColorImageResolution=$(COMPRESSION_IMAGE_DPI)
 
 COMPRESSION_FLAGS_1 += -dDownsampleGrayImages=true
 COMPRESSION_FLAGS_1 += -dGrayImageDownsampleThreshold=1.5
 COMPRESSION_FLAGS_1 += -dGrayImageDownsampleType=/Bicubic
 COMPRESSION_FLAGS_1 += -dGrayImageFilter=/DCTEncode
-COMPRESSION_FLAGS_1 += -dGrayImageResolution=144
+COMPRESSION_FLAGS_1 += -dGrayImageResolution=$(COMPRESSION_IMAGE_DPI)
 
 COMPRESSION_FLAGS_1 += -dDownsampleMonoImages=true
 COMPRESSION_FLAGS_1 += -dMonoImageDownsampleThreshold=1.5
 COMPRESSION_FLAGS_1 += -dMonoImageDownsampleType=/Subsample
 COMPRESSION_FLAGS_1 += -dMonoImageFilter=/CCITTFaxEncode
-COMPRESSION_FLAGS_1 += -dMonoImageResolution=144
+COMPRESSION_FLAGS_1 += -dMonoImageResolution=$(COMPRESSION_IMAGE_DPI)
 
 
 ##! сжатие файла с потерей данных
 compress-lowdpi:
 	$(MSYS_FIX) ps2pdf $(COMPRESSION_FLAGS_1) \
-	                   $(COMPRESS_FILE).pdf $(COMPRESS_FILE)_lowdpi.pdf
+	                   $(basename $(COMPRESS_FILE)).pdf $(basename $(COMPRESS_FILE))_lowdpi.pdf
 
 
 
@@ -143,6 +144,6 @@ COMPRESSION_FLAGS_2 += -dMonoImageFilter=/FlateEncode
 ##! сжатие файла с конвертацией в CMYK
 compress-cmyk:
 	$(MSYS_FIX) ps2pdf $(COMPRESSION_FLAGS_2) \
-	                   $(COMPRESS_FILE).pdf $(COMPRESS_FILE)_cmyk.pdf
+	                   $(basename $(COMPRESS_FILE)).pdf $(basename $(COMPRESS_FILE))_cmyk.pdf
 
 .PHONY: compress-lowdpi compress-cmyk


### PR DESCRIPTION
<!-- Подробнее об оформлении PR можно прочитать в документе https://github.com/AndreyAkinshin/Russian-Phd-LaTeX-Dissertation-Template/blob/master/CONTRIBUTING.md -->

## PR checklist

Пожалуйста, убедитесь, что Ваш PR удовлетворяет требованиям:

- [ ] Изменения были протестированы (`make examples`)
- [ ] Изменения отражены в документации к шаблону
- [ ] Код соответствует правилам индентации шаблона (`make indent`)


## Тип PR

Отметьте графы, которые относятся к данному PR:

- [ ] Bugfix
- [x] Feature
- [ ] Форматирование стиля кода
- [ ] Изменение текста шаблона
- [ ] Изменение документации
- [ ] Другое:


## Описание PR
<!-- Описание изменений. -->

1. В `compress.mk` добавлена переменная `COMPRESSION_IMAGE_DPI` для управления DPI изображения из командной строки.
2. Код изменён так, чтобы параметр `COMPRESS_FILE` принимал в качестве аргумента название файла как с расширением `.pdf`, так и без.

## Смежные обсуждения
<!-- Ссылки на PR и issue, к которым относится данный PR. -->

Данный PR закрывает issue:

## Тестирование шаблона
<!-- Эта часть в будущем должна быть автоматизирована -->

Тестирование производилось в среде

- [ ] Windows
- [ ] Windows Cygwin
- [x] GNU/Linux (на основе Debian)
- [ ] GNU/Linux (на основе RedHat)
- [ ] Arch Linux
- [ ] Docker (ссылка на контейнер):

## Другая информация
