### PR TITLE
Исправление подписей рисунков и таблиц автореферата

### DIFF
--- a/Dissertation/renames.tex
+++ b/Dissertation/renames.tex
@@ -1,0 +1,8 @@
+% Переопределения названий для nomencl. Так как опция russian не для utf8
+\renewcommand{\nomname}{Список сокращений и условных обозначений}%
+\renewcommand{\eqdeclaration}[1]{, см.~(#1)}%
+\renewcommand{\pagedeclaration}[1]{, стр.~#1}%
+\renewcommand{\nomAname}{Латинские буквы}%
+\renewcommand{\nomGname}{Греческие буквы}%
+\renewcommand{\nomXname}{Верхние индексы}%
+\renewcommand{\nomZname}{Индексы}%

--- a/common/renames.tex
+++ b/common/renames.tex
@@ -5,11 +5,3 @@
 \renewcommand{\listfigurename}{Список рисунков}%
 \renewcommand{\listtablename}{Список таблиц}%
 \renewcommand{\bibname}{\bibtitlefull}%
-% Переопределения названий для nomencl. Так как опция russian не для utf8
-\renewcommand{\nomname}{Список сокращений и условных обозначений}%
-\renewcommand{\eqdeclaration}[1]{, см.~(#1)}%
-\renewcommand{\pagedeclaration}[1]{, стр.~#1}%
-\renewcommand{\nomAname}{Латинские буквы}%
-\renewcommand{\nomGname}{Греческие буквы}%
-\renewcommand{\nomXname}{Верхние индексы}%
-\renewcommand{\nomZname}{Индексы}%

--- a/dissertation.tex
+++ b/dissertation.tex
@@ -54,6 +54,8 @@
 % https://tex.stackexchange.com/a/156050
 \gappto\captionsrussian{\input{common/renames}} % for polyglossia and babel
 \input{common/renames}
+\gappto\captionsrussian{\input{Dissertation/renames}} % for polyglossia and babel
+\input{Dissertation/renames}
 
 %%% Структура диссертации (ГОСТ Р 7.0.11-2011, 4)
 \include{Dissertation/title}           % Титульный лист

--- a/synopsis.tex
+++ b/synopsis.tex
@@ -38,6 +38,10 @@
 \listfiles
 
 \begin{document}
+%%% Переопределение именований типовых разделов
+% https://tex.stackexchange.com/a/156050
+\gappto\captionsrussian{\input{common/renames}} % for polyglossia and babel
+\input{common/renames}
 
 \input{Synopsis/title}        % Титульный лист
 %\mainmatter                   % В том числе начинает нумерацию страниц арабскими цифрами с единицы


### PR DESCRIPTION
Fix #510

Как-то упустили, чт ов автореферате подписи у рисунков были не такими как в диссертации (и требуется по ГОСТ). 