### PR TITLE
Fix biblatex refsection extra par

### DIFF
--- a/common/characteristic.tex
+++ b/common/characteristic.tex
@@ -111,7 +111,7 @@
         %  * при использовании `\insertbiblioauthorgrouped`, порядок команд `\printbibliography` в нём должен быть тем же (см. biblio/biblatex.tex)
         %
         % Невидимый библиографический список для подсчёта количества публикаций:
-        \printbibliography[heading=nobibheading, section=1, env=countauthorvak,          keyword=biblioauthorvak]%
+        \phantom{\printbibliography[heading=nobibheading, section=1, env=countauthorvak,          keyword=biblioauthorvak]%
         \printbibliography[heading=nobibheading, section=1, env=countauthorwos,          keyword=biblioauthorwos]%
         \printbibliography[heading=nobibheading, section=1, env=countauthorscopus,       keyword=biblioauthorscopus]%
         \printbibliography[heading=nobibheading, section=1, env=countauthorconf,         keyword=biblioauthorconf]%
@@ -121,7 +121,7 @@
         \printbibliography[heading=nobibheading, section=1, env=countauthorprogram,      keyword=biblioauthorprogram]%
         \printbibliography[heading=nobibheading, section=1, env=countauthor,             keyword=biblioauthor]%
         \printbibliography[heading=nobibheading, section=1, env=countauthorvakscopuswos, filter=vakscopuswos]%
-        \printbibliography[heading=nobibheading, section=1, env=countauthorscopuswos,    filter=scopuswos]%
+        \printbibliography[heading=nobibheading, section=1, env=countauthorscopuswos,    filter=scopuswos]}%
         %
         \nocite{*}%
         %

--- a/common/characteristic.tex
+++ b/common/characteristic.tex
@@ -126,9 +126,9 @@
         \nocite{*}%
         %
         {\publications} Основные результаты по теме диссертации изложены в~\arabic{citeauthor}~печатных изданиях,
-        \arabic{citeauthorvak} из которых изданы в журналах, рекомендованных ВАК\sloppy%
+        \arabic{citeauthorvak} из которых изданы в журналах, рекомендованных ВАК%
         \ifnum \value{citeauthorscopuswos}>0%
-            , \arabic{citeauthorscopuswos} "--- в~периодических научных журналах, индексируемых Web of~Science и Scopus\sloppy%
+            , \arabic{citeauthorscopuswos} "--- в~периодических научных журналах, индексируемых Web of~Science и Scopus%
         \fi%
         \ifnum \value{citeauthorconf}>0%
             , \arabic{citeauthorconf} "--- в~тезисах докладов.
@@ -146,7 +146,7 @@
         \ifnum \value{citeregistered}>1%
             Зарегистрированы\ %
             \ifnum \value{citeauthorpatent}>0%
-            \formbytotal{citeauthorpatent}{патент}{}{а}{}\sloppy%
+            \formbytotal{citeauthorpatent}{патент}{}{а}{}%
             \ifnum \value{citeauthorprogram}=0 . \else \ и~\fi%
             \fi%
             \ifnum \value{citeauthorprogram}>0%


### PR DESCRIPTION
<!-- Подробнее об оформлении PR можно прочитать в документе https://github.com/AndreyAkinshin/Russian-Phd-LaTeX-Dissertation-Template/blob/master/CONTRIBUTING.md -->

## PR checklist

Пожалуйста, убедитесь, что Ваш PR удовлетворяет требованиям:

- [x] Изменения были протестированы (`make examples`)
- [ ] Изменения отражены в документации к шаблону
- [ ] Код соответствует правилам индентации шаблона (`make indent`)


## Тип PR

Отметьте графы, которые относятся к данному PR:

- [x] Bugfix

## Описание PR
<!-- Описание изменений. -->

- Убраны команды \sloppy из файла characteristic чтобы не словить неожиданностей в будущем: https://tex.stackexchange.com/a/241355 (если прям надо будет, то лучше будет обрамить в sloppypar окружение)
- с каким-то из новых biblatex в "невидимых" \prinbibliography появляется как будто \par. Это видно на свежем TeXLive2024 обновленном. Правка обрамляет в \phantom, чтобы невидимость получить иначе. На TexLive 2023 проверено что изменений не видно


## Тестирование шаблона
<!-- Эта часть в будущем должна быть автоматизирована -->

Тестирование производилось в среде

- [x] Windows
- [x] GNU/Linux (на основе Debian)
