### PR TITLE
Фикс проблем с subcaptionref ссылками при необновлённом TL2025

### DIFF
--- a/common/styles.tex
+++ b/common/styles.tex
@@ -62,6 +62,25 @@
 }
 
 %%% Настройки ссылок на рисунки, таблицы и др. %%%
+% Фикс проблемы со ссылками \subcaptionref в необновлённом TeXLive 2025 и memoir
+\makeatletter
+\@ifclasslater{memoir}{2025/09/22}{%
+% Считаем, что версии memoir новее будут взаимодействовать с amsmath и label корректнее
+}{
+  \@ifclasslater{memoir}{2025/03/10}{%
+  % Эта версия memoir некорректно взаимодействует с обновлённым amsmath
+    \renewcommand{\memsubfig@captionpar}[2]{%
+      \parbox[t]{#1}{\let\label=\memsub@label\@subcapsize\@contsubcstyle #2}}
+  }{}
+}
+% Фикс проблемы со ссылками пакета subcaption и обновлённого amsmath
+\@ifpackagelater{amsmath}{2025/01/11}{
+% https://tex.stackexchange.com/a/746030
+  \patchcmd\caption@subtypehook{\let\label\subcaption@label}
+    {\let\label\subcaption@label\let\ltx@label\subcaption@label}{}{\fail}
+}{}
+\makeatother
+
 % команды \cref...format отвечают за форматирование при помощи команды \cref
 % команды \labelcref...format отвечают за форматирование при помощи команды \labelcref
 


### PR DESCRIPTION
## PR checklist

- [±] Изменения были протестированы (`make examples`)
- [ ] Изменения отражены в документации к шаблону
- [ ] Код соответствует правилам индентации шаблона (`make indent`)


## Тип PR

Отметьте графы, которые относятся к данному PR:

- [x] Bugfix

## Описание PR

В TeXLive 2025 обновили/упорядочили работу с label, также полечили 30-летний баг в amsmath. 
В результате всплыли проблемы с subcaptionref в memoir (там починят при очередном обновлении).
Также всплыли проблемы в subcaption с работой с ref ссылками в subcaptionbox (там вряд ли пофиксят в обозримое время, так как пакет caption/subaption ищет maintainer).
Из-за этих проблем в TeXLive 2025 примеры работы subcaptionref из этого шаблона показывают `??` вместо положенных букв у ссылок на рисунки.
Этот PR решает эту проблему.
Работоспособность проверил вручную на pdflatex в TL2023, TL2024 и TL2025.

Дополнительная информация:
- https://github.com/latex3/latex2e/issues/1861#issuecomment-3318123561
- https://gitlab.com/axelsommerfeldt/caption/-/issues/184 


## Тестирование шаблона
<!-- Эта часть в будущем должна быть автоматизирована -->

Тестирование производилось в среде

- [ ] Windows
- [ ] Windows Cygwin
- [x] GNU/Linux (на основе Debian)
- [ ] GNU/Linux (на основе RedHat)
- [ ] Arch Linux
- [ ] Docker (ссылка на контейнер):


